### PR TITLE
Implement Hessian Sharding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.vscode/
 
 # C extensions
 *.so

--- a/examples/openwebtext/fit_factors.py
+++ b/examples/openwebtext/fit_factors.py
@@ -3,7 +3,7 @@ import logging
 from datetime import timedelta
 
 import torch
-from accelerate import Accelerator, InitProcessGroupKwargs
+from accelerate import Accelerator, InitProcessGroupKwargs, FullyShardedDataParallelPlugin
 from transformers import default_data_collator
 
 from examples.openwebtext.pipeline import construct_llama3, get_openwebtext_dataset
@@ -45,6 +45,12 @@ def parse_args():
         default=False,
         help="Boolean flag to profile computations.",
     )
+    parser.add_argument(
+        "--use_fsdp",
+        action="store_true",
+        default=False,
+        help="Boolean flag to use FSDP.",
+    )
     args = parser.parse_args()
 
     return args
@@ -80,12 +86,17 @@ def main():
 
     factors_name = args.factors_name
     factor_args = extreme_reduce_memory_factor_arguments(
-        strategy=args.factor_strategy, module_partitions=1, dtype=torch.bfloat16
+        strategy=args.factor_strategy, module_partitions=1, dtype=torch.float32
     )
     factor_args.covariance_module_partitions = 2
     factor_args.lambda_module_partitions = 4
-    factor_args.covariance_data_partitions = 4
-    factor_args.lambda_data_partitions = 4
+    factor_args.covariance_data_partitions = 1
+    factor_args.lambda_data_partitions = 1
+
+    factor_args.shard_covariance = args.use_fsdp
+    factor_args.shard_lambda = args.use_fsdp
+    factor_args.shard_eigendecomposition = args.use_fsdp
+
     analyzer.fit_all_factors(
         factors_name=factors_name,
         dataset=train_dataset,

--- a/examples/openwebtext/influence_results
+++ b/examples/openwebtext/influence_results
@@ -1,0 +1,1 @@
+/mfs1/u/levmckinney/experiments/kronfluence

--- a/examples/openwebtext/pipeline.py
+++ b/examples/openwebtext/pipeline.py
@@ -7,6 +7,8 @@ from torch import nn
 from torch.utils import data
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
+from kronfluence.utils.model import apply_fsdp
+
 MODEL_NAME = "meta-llama/Meta-Llama-3-8B"
 # MODEL_NAME = "EleutherAI/pythia-70m"
 MAX_LENGTH = 512
@@ -25,6 +27,8 @@ def construct_llama3() -> nn.Module:
     )
     return model
 
+def apply_fsdp_to_llama3(model: nn.Module) -> nn.Module:
+    return apply_fsdp(model, sequential=model.model.layers, cpu_offload=False)
 
 def get_openwebtext_dataset(
     indices: List[int] = None,

--- a/examples/wikitext/analyze.py
+++ b/examples/wikitext/analyze.py
@@ -8,7 +8,7 @@ import torch.nn.functional as F
 from torch import nn
 from transformers import default_data_collator
 
-from examples.wikitext.pipeline import construct_gpt2, get_wikitext_dataset
+from examples.wikitext.pipeline import apply_fsdp_to_gpt2, construct_gpt2, get_wikitext_dataset
 from kronfluence.analyzer import Analyzer, prepare_model
 from kronfluence.arguments import FactorArguments, ScoreArguments
 from kronfluence.task import Task
@@ -28,7 +28,11 @@ def parse_args():
         default="./checkpoints",
         help="A path that is storing the final checkpoint of the model.",
     )
-
+    parser.add_argument(
+        "--apply_fsdp",
+        action="store_true",
+        help="Whether to apply FSDP to the model.",
+    )
     parser.add_argument(
         "--factor_strategy",
         type=str,
@@ -64,6 +68,12 @@ def parse_args():
         type=int,
         default=8,
         help="Batch size for computing query gradients.",
+    )
+    parser.add_argument(
+        "--factor_batch_size",
+        type=int,
+        default=64,
+        help="Batch size for computing factors.",
     )
     parser.add_argument(
         "--compute_per_token_scores",
@@ -152,6 +162,7 @@ def main():
 
     # Prepare the trained model.
     model = construct_gpt2()
+
     checkpoint_path = os.path.join(args.checkpoint_dir, "model.pth")
     if not os.path.isfile(checkpoint_path):
         raise ValueError(f"No checkpoint found at {checkpoint_path}.")
@@ -160,6 +171,9 @@ def main():
     # Define task and prepare model.
     task = LanguageModelingTask()
     model = prepare_model(model, task)
+
+    if args.apply_fsdp:
+        model = apply_fsdp_to_gpt2(model)
 
     if args.use_compile:
         model = torch.compile(model)
@@ -177,17 +191,27 @@ def main():
     # Compute influence factors.
     factors_name = args.factor_strategy
     factor_args = FactorArguments(strategy=args.factor_strategy)
+    
     if args.use_half_precision:
         factor_args = all_low_precision_factor_arguments(strategy=args.factor_strategy, dtype=torch.bfloat16)
         factors_name += "_half"
+    
     if args.use_compile:
         factors_name += "_compile"
+    
+    factor_args.lambda_max_examples = 128
+    factor_args.covariance_max_examples = 128
+
+    if args.apply_fsdp:
+        factor_args.shard_covariance = True
+        factor_args.shard_eigendecomposition = True
+        factor_args.shard_lambda = True
+
     analyzer.fit_all_factors(
         factors_name=factors_name,
         dataset=train_dataset,
-        per_device_batch_size=None,
         factor_args=factor_args,
-        initial_per_device_batch_size_attempt=64,
+        per_device_batch_size=args.factor_batch_size,
         overwrite_output_dir=False,
     )
 

--- a/examples/wikitext/pipeline.py
+++ b/examples/wikitext/pipeline.py
@@ -5,9 +5,9 @@ import torch
 from datasets import load_dataset
 from torch import nn
 from torch.utils import data
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, GPT2LMHeadModel
+from kronfluence.utils.model import apply_fsdp
 from transformers.pytorch_utils import Conv1D
-
 
 @torch.no_grad()
 def replace_conv1d_modules(model: nn.Module) -> None:
@@ -39,6 +39,9 @@ def construct_gpt2() -> nn.Module:
     replace_conv1d_modules(model)
     return model
 
+
+def apply_fsdp_to_gpt2(model: GPT2LMHeadModel) -> nn.Module:
+    return apply_fsdp(model, sequential=model.transformer.h, cpu_offload=False)
 
 def get_wikitext_dataset(
     split: str,

--- a/examples/wikitext/train.py
+++ b/examples/wikitext/train.py
@@ -8,9 +8,12 @@ import torch
 from accelerate.utils import set_seed
 from torch import nn
 from torch.utils import data
+from tqdm import tqdm
+from torch.nn.parallel import DistributedDataParallel as DDP
 from transformers import default_data_collator
 
-from examples.wikitext.pipeline import construct_gpt2, get_wikitext_dataset
+from examples.wikitext.pipeline import apply_fsdp_to_gpt2, construct_gpt2, get_wikitext_dataset
+from kronfluence.utils.state import State
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
@@ -46,7 +49,7 @@ def parse_args():
     parser.add_argument(
         "--num_train_epochs",
         type=int,
-        default=3,
+        default=1,
         help="Total number of epochs to train the model.",
     )
 
@@ -62,6 +65,11 @@ def parse_args():
         default="./checkpoints",
         help="A path to store the final checkpoint.",
     )
+    parser.add_argument(
+        "--apply_fsdp",
+        action="store_true",
+        help="Whether to apply FSDP to the model.",
+    )
     args = parser.parse_args()
 
     if args.checkpoint_dir is not None:
@@ -76,23 +84,29 @@ def train(
     num_train_epochs: int,
     learning_rate: float,
     weight_decay: float,
+    apply_fsdp: bool,
 ) -> nn.Module:
     train_dataloader = data.DataLoader(
         dataset=dataset,
         batch_size=batch_size,
-        shuffle=True,
         drop_last=True,
         collate_fn=default_data_collator,
+        sampler=torch.utils.data.DistributedSampler(dataset, shuffle=True),
     )
 
     model = construct_gpt2().to(DEVICE)
+    if apply_fsdp:
+        model = apply_fsdp_to_gpt2(model)
+    else:
+        model = DDP(model)
+
     optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate, weight_decay=weight_decay)
 
     start_time = time.time()
     model.train()
     for epoch in range(num_train_epochs):
         total_loss = 0.0
-        for batch in train_dataloader:
+        for batch in tqdm(train_dataloader):
             optimizer.zero_grad(set_to_none=True)
             loss = model(
                 input_ids=batch["input_ids"].to(device=DEVICE),
@@ -102,6 +116,7 @@ def train(
             loss.backward()
             optimizer.step()
             total_loss += loss.detach().float() * batch["input_ids"].shape[0]
+        torch.distributed.all_reduce(total_loss, op=torch.distributed.ReduceOp.SUM)
         logging.info(f"Epoch {epoch + 1} - Averaged Loss: {total_loss / len(dataset)}")
     end_time = time.time()
     elapsed_time = end_time - start_time
@@ -111,12 +126,16 @@ def train(
 
 def evaluate_model(model: nn.Module, dataset: data.Dataset, batch_size: int) -> float:
     dataloader = data.DataLoader(
-        dataset=dataset, batch_size=batch_size, shuffle=False, drop_last=False, collate_fn=default_data_collator
+        dataset=dataset,
+        batch_size=batch_size,
+        drop_last=False,
+        collate_fn=default_data_collator,
+        sampler=torch.utils.data.DistributedSampler(dataset, shuffle=False),
     )
 
     model.eval()
-    total_loss = 0.0
-    total_num = 0
+    total_loss = torch.tensor(0.0, device=DEVICE)
+    total_num = torch.tensor(0, device=DEVICE)
     for batch in dataloader:
         with torch.no_grad():
             loss = model(
@@ -126,6 +145,8 @@ def evaluate_model(model: nn.Module, dataset: data.Dataset, batch_size: int) -> 
             ).loss
             total_loss += loss.detach() * batch["input_ids"].shape[0]
             total_num += batch["input_ids"].shape[0]
+    torch.distributed.all_reduce(total_loss, op=torch.distributed.ReduceOp.SUM)
+    torch.distributed.all_reduce(total_num, op=torch.distributed.ReduceOp.SUM)
     return total_loss.item() / total_num
 
 
@@ -133,6 +154,7 @@ def main():
     args = parse_args()
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger()
+    state = State()
 
     if args.seed is not None:
         set_seed(args.seed)
@@ -142,6 +164,7 @@ def main():
         dataset=train_dataset,
         batch_size=args.train_batch_size,
         num_train_epochs=args.num_train_epochs,
+        apply_fsdp=args.apply_fsdp,
         learning_rate=args.learning_rate,
         weight_decay=args.weight_decay,
     )
@@ -159,8 +182,13 @@ def main():
         eval_perplexity = float("inf")
     logger.info(f"Evaluation perplexity: {eval_perplexity}")
 
-    if args.checkpoint_dir is not None:
-        torch.save(model.state_dict(), os.path.join(args.checkpoint_dir, "model.pth"))
+    if args.apply_fsdp:
+        model.unshard()
+    else:
+        model = model.module
+
+    if args.checkpoint_dir is not None and state.is_main_process:
+       torch.save(model.state_dict(), os.path.join(args.checkpoint_dir, "model.pth"))
 
 
 if __name__ == "__main__":

--- a/kronfluence/arguments.py
+++ b/kronfluence/arguments.py
@@ -80,6 +80,10 @@ class FactorArguments(Arguments):
             "covariance matrix computation."
         },
     )
+    shard_covariance: bool = field(
+        default=False,
+        metadata={"help": "If `True`, shards the covariance matrix across the model's modules (layers)."},
+    )
     activation_covariance_dtype: torch.dtype = field(
         default=torch.float32,
         metadata={"help": "Data type for activation covariance computation."},
@@ -112,6 +116,10 @@ class FactorArguments(Arguments):
         metadata={
             "help": "Number of partitions to divide the model's modules (layers) into for Lambda matrix computation."
         },
+    )
+    shard_lambda: bool = field(
+        default=False,
+        metadata={"help": "If `True`, shards the Lambda matrix across the model's modules (layers)."},
     )
     use_iterative_lambda_aggregation: bool = field(
         default=False,

--- a/kronfluence/arguments.py
+++ b/kronfluence/arguments.py
@@ -101,6 +101,10 @@ class FactorArguments(Arguments):
             "for numerical stability."
         },
     )
+    shard_eigendecomposition: bool = field(
+        default=False,
+        metadata={"help": "If `True`, shards the eigendecomposition across the model's modules (layers)."},
+    )
 
     # Configuration for fitting Lambda matrices #
     lambda_max_examples: Optional[int] = field(

--- a/kronfluence/computer/computer.py
+++ b/kronfluence/computer/computer.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 from torch import nn
-from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp import FSDPModule
 from torch.nn import DataParallel
 from torch.nn.parallel.distributed import DistributedDataParallel as DDP
 from torch.utils import data
@@ -90,7 +90,7 @@ class Computer(ABC):
             raise TrackedModuleNotFoundError(error_msg)
         self.logger.info(f"Tracking modules with names: {tracked_module_names}.")
 
-        if self.state.use_distributed and not isinstance(model, (DDP, FSDP)):
+        if self.state.use_distributed and not isinstance(model, (DDP, FSDPModule)):
             self.logger.warning(
                 "Creating a DDP module. For custom DDP configuration, "
                 "please manually wrap the model with DDP before passing it in."
@@ -102,7 +102,7 @@ class Computer(ABC):
                 output_device=self.state.local_process_index,
             )
 
-        if cpu and isinstance(model, (DataParallel, DDP, FSDP)):
+        if cpu and isinstance(model, (DataParallel, DDP, FSDPModule)):
             error_msg = (
                 "CPU enforcement is incompatible with DP, DDP, or FSDP wrapped models. "
                 "Please provide an unwrapped model when using `cpu=True`."

--- a/kronfluence/computer/computer.py
+++ b/kronfluence/computer/computer.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 from torch import nn
-from torch.distributed.fsdp import FSDPModule
+from torch.distributed.fsdp import FSDPModule, FullyShardedDataParallel as FSDP1
 from torch.nn import DataParallel
 from torch.nn.parallel.distributed import DistributedDataParallel as DDP
 from torch.utils import data
@@ -90,7 +90,7 @@ class Computer(ABC):
             raise TrackedModuleNotFoundError(error_msg)
         self.logger.info(f"Tracking modules with names: {tracked_module_names}.")
 
-        if self.state.use_distributed and not isinstance(model, (DDP, FSDPModule)):
+        if self.state.use_distributed and not isinstance(model, (DDP, FSDPModule, FSDP1)):
             self.logger.warning(
                 "Creating a DDP module. For custom DDP configuration, "
                 "please manually wrap the model with DDP before passing it in."

--- a/kronfluence/computer/factor_computer.py
+++ b/kronfluence/computer/factor_computer.py
@@ -305,7 +305,7 @@ class FactorComputer(Computer):
                         per_device_batch_size=per_device_batch_size,
                         dataloader_params=dataloader_params,
                         indices=list(range(start_index, end_index)),
-                        allow_duplicates=False,
+                        allow_duplicates=True,
                     )
                     num_data_processed, covariance_factors = fit_covariance_matrices_with_loader(
                         model=self.model,
@@ -662,7 +662,7 @@ class FactorComputer(Computer):
                         per_device_batch_size=per_device_batch_size,
                         dataloader_params=dataloader_params,
                         indices=list(range(start_index, end_index)),
-                        allow_duplicates=False,
+                        allow_duplicates=True,
                     )
                     num_data_processed, lambda_factors = fit_lambda_matrices_with_loader(
                         eigen_factors=eigen_factors,

--- a/kronfluence/computer/factor_computer.py
+++ b/kronfluence/computer/factor_computer.py
@@ -560,16 +560,20 @@ class FactorComputer(Computer):
         if FactorConfig.CONFIGS[factor_args.strategy].requires_eigendecomposition_for_lambda:
             with self.profiler.profile("Load Eigendecomposition"):
                 eigen_factors = load_eigendecomposition(output_dir=load_factors_output_dir)
+
             if load_from_factors_name is not None and self.state.is_main_process:
                 with self.profiler.profile("Save Eigendecomposition"):
                     save_eigendecomposition(output_dir=factors_output_dir, factors=eigen_factors)
+
                 loaded_factor_args = self.load_factor_args(factors_name=load_from_factors_name)
+
                 self._save_arguments(
                     arguments_name=FACTOR_ARGUMENTS_NAME + "_loaded_eigendecomposition",
                     arguments=loaded_factor_args,
                     output_dir=factors_output_dir,
                     overwrite_output_dir=True,
                 )
+
             self.state.wait_for_everyone()
 
         if factor_args.lambda_max_examples is None:

--- a/kronfluence/factor/config.py
+++ b/kronfluence/factor/config.py
@@ -14,9 +14,7 @@ from kronfluence.utils.constants import (
     LAMBDA_MATRIX_NAME,
     NUM_LAMBDA_PROCESSED,
 )
-
-STORAGE_TYPE = Dict[str, Any]
-
+from kronfluence.utils.sharded_storage import ShardedStorage
 
 class FactorStrategy(str, BaseEnum):
     """Strategies for computing preconditioning factors."""
@@ -89,11 +87,11 @@ class FactorConfig(metaclass=ABCMeta):
         the preconditioned gradient."""
         raise NotImplementedError("Subclasses must implement the `requires_lambda_matrices_for_precondition` property.")
 
-    def prepare(self, storage: STORAGE_TYPE, score_args: Any, device: torch.device) -> None:
+    def prepare(self, storage: ShardedStorage, score_args: Any, device: torch.device) -> None:
         """Performs necessary operations before computing the preconditioned gradient.
 
         Args:
-            storage (STORAGE_TYPE):
+            storage (SharededStorage):
                 A dictionary containing various factors required to compute the preconditioned gradient.
                 See `.storage` in `TrackedModule` for details.
             score_args (ScoreArguments):
@@ -106,7 +104,7 @@ class FactorConfig(metaclass=ABCMeta):
     def precondition_gradient(
         self,
         gradient: torch.Tensor,
-        storage: STORAGE_TYPE,
+        storage: ShardedStorage,
     ) -> torch.Tensor:
         """Preconditions the per-sample gradient. The per-sample gradient is a 3-dimensional
         tensor with shape `batch_size x output_dim x input_dim`.
@@ -114,7 +112,7 @@ class FactorConfig(metaclass=ABCMeta):
         Args:
             gradient (torch.Tensor):
                 The per-sample gradient tensor.
-            storage (STORAGE_TYPE):
+            storage (ShardedStorage):
                 A dictionary containing various factors required to compute the preconditioned gradient.
                 See `.storage` in `TrackedModule` for details.
 
@@ -159,7 +157,7 @@ class Identity(FactorConfig, factor_strategy=FactorStrategy.IDENTITY):
     def precondition_gradient(
         self,
         gradient: torch.Tensor,
-        storage: STORAGE_TYPE,
+        storage: ShardedStorage,
     ) -> torch.Tensor:
         del storage
         return gradient
@@ -196,21 +194,23 @@ class Diagonal(FactorConfig, factor_strategy=FactorStrategy.DIAGONAL):
     def requires_lambda_matrices_for_precondition(self) -> bool:
         return True
 
-    def prepare(self, storage: STORAGE_TYPE, score_args: Any, device: torch.device) -> None:
+    def prepare(self, storage: ShardedStorage, score_args: Any, device: torch.device) -> None:
         lambda_matrix = storage[LAMBDA_MATRIX_NAME].to(dtype=LAMBDA_DTYPE, device=device)
+        del storage[LAMBDA_MATRIX_NAME]
+
         lambda_matrix.div_(storage[NUM_LAMBDA_PROCESSED].to(device=device))
         damping_factor = score_args.damping_factor
         if damping_factor is None:
             damping_factor = HEURISTIC_DAMPING_SCALE * torch.mean(lambda_matrix)
         lambda_matrix.add_(damping_factor)
         lambda_matrix.reciprocal_()
+        del storage[NUM_LAMBDA_PROCESSED]
         storage[LAMBDA_MATRIX_NAME] = lambda_matrix.to(dtype=score_args.precondition_dtype, device="cpu").contiguous()
-        storage[NUM_LAMBDA_PROCESSED] = None
 
     def precondition_gradient(
         self,
         gradient: torch.Tensor,
-        storage: STORAGE_TYPE,
+        storage: ShardedStorage,
     ) -> torch.Tensor:
         lambda_matrix = storage[LAMBDA_MATRIX_NAME].to(device=gradient.device)
         return gradient * lambda_matrix
@@ -250,31 +250,40 @@ class Kfac(FactorConfig, factor_strategy=FactorStrategy.KFAC):
     def requires_lambda_matrices_for_precondition(self) -> bool:
         return False
 
-    def prepare(self, storage: STORAGE_TYPE, score_args: Any, device: torch.device) -> None:
-        storage[ACTIVATION_EIGENVECTORS_NAME] = (
-            storage[ACTIVATION_EIGENVECTORS_NAME].to(dtype=score_args.precondition_dtype).contiguous()
-        )
-        storage[GRADIENT_EIGENVECTORS_NAME] = (
-            storage[GRADIENT_EIGENVECTORS_NAME].to(dtype=score_args.precondition_dtype).contiguous()
-        )
+    def prepare(self, storage: ShardedStorage, score_args: Any, device: torch.device) -> None:
+        activation_eigenvectors = storage[ACTIVATION_EIGENVECTORS_NAME].to(dtype=score_args.precondition_dtype).contiguous()
+        del storage[ACTIVATION_EIGENVECTORS_NAME]
+        storage[ACTIVATION_EIGENVECTORS_NAME] = activation_eigenvectors
+        
+        gradient_eigenvectors = storage[GRADIENT_EIGENVECTORS_NAME].to(dtype=score_args.precondition_dtype).contiguous()
+        del storage[GRADIENT_EIGENVECTORS_NAME]
+        storage[GRADIENT_EIGENVECTORS_NAME] = gradient_eigenvectors
+        
         activation_eigenvalues = storage[ACTIVATION_EIGENVALUES_NAME].to(dtype=LAMBDA_DTYPE, device=device)
         gradient_eigenvalues = storage[GRADIENT_EIGENVALUES_NAME].to(dtype=LAMBDA_DTYPE, device=device)
+        
         lambda_matrix = torch.kron(activation_eigenvalues.unsqueeze(0), gradient_eigenvalues.unsqueeze(-1)).unsqueeze(0)
+        del storage[LAMBDA_MATRIX_NAME]
+
         damping_factor = score_args.damping_factor
+        
         if damping_factor is None:
             damping_factor = HEURISTIC_DAMPING_SCALE * torch.mean(lambda_matrix)
+        
         lambda_matrix.add_(damping_factor)
         lambda_matrix.reciprocal_()
+
         storage[LAMBDA_MATRIX_NAME] = lambda_matrix.to(dtype=score_args.precondition_dtype, device="cpu").contiguous()
-        storage[NUM_LAMBDA_PROCESSED] = None
-        storage[ACTIVATION_EIGENVALUES_NAME] = None
-        storage[GRADIENT_EIGENVALUES_NAME] = None
+        
+        del storage[NUM_LAMBDA_PROCESSED]
+        del storage[ACTIVATION_EIGENVALUES_NAME]
+        del storage[GRADIENT_EIGENVALUES_NAME]
 
     @torch.no_grad()
     def precondition_gradient(
         self,
         gradient: torch.Tensor,
-        storage: STORAGE_TYPE,
+        storage: ShardedStorage,
     ) -> torch.Tensor:
         activation_eigenvectors = storage[ACTIVATION_EIGENVECTORS_NAME].to(device=gradient.device)
         gradient_eigenvectors = storage[GRADIENT_EIGENVECTORS_NAME].to(device=gradient.device)
@@ -319,30 +328,35 @@ class Ekfac(FactorConfig, factor_strategy=FactorStrategy.EKFAC):
     def requires_lambda_matrices_for_precondition(self) -> bool:
         return True
 
-    def prepare(self, storage: STORAGE_TYPE, score_args: Any, device: torch.device) -> None:
-        storage[ACTIVATION_EIGENVECTORS_NAME] = (
-            storage[ACTIVATION_EIGENVECTORS_NAME].to(dtype=score_args.precondition_dtype).contiguous()
-        )
-        storage[GRADIENT_EIGENVECTORS_NAME] = (
-            storage[GRADIENT_EIGENVECTORS_NAME].to(dtype=score_args.precondition_dtype).contiguous()
-        )
-        storage[ACTIVATION_EIGENVALUES_NAME] = None
-        storage[GRADIENT_EIGENVALUES_NAME] = None
+    def prepare(self, storage: ShardedStorage, score_args: Any, device: torch.device) -> None:
+        activation_eigenvectors = storage[ACTIVATION_EIGENVECTORS_NAME].to(dtype=score_args.precondition_dtype).contiguous()
+        del storage[ACTIVATION_EIGENVECTORS_NAME]
+        storage[ACTIVATION_EIGENVECTORS_NAME] = activation_eigenvectors
+        
+        gradient_eigenvectors = storage[GRADIENT_EIGENVECTORS_NAME].to(dtype=score_args.precondition_dtype).contiguous()
+        del storage[GRADIENT_EIGENVECTORS_NAME]
+        storage[GRADIENT_EIGENVECTORS_NAME] = gradient_eigenvectors
+
+        del storage[ACTIVATION_EIGENVALUES_NAME]
+        del storage[GRADIENT_EIGENVALUES_NAME]
         lambda_matrix = storage[LAMBDA_MATRIX_NAME].to(dtype=LAMBDA_DTYPE, device=device)
+        del storage[LAMBDA_MATRIX_NAME]
+
         lambda_matrix.div_(storage[NUM_LAMBDA_PROCESSED].to(device=device))
         damping_factor = score_args.damping_factor
         if damping_factor is None:
             damping_factor = HEURISTIC_DAMPING_SCALE * torch.mean(lambda_matrix)
         lambda_matrix.add_(damping_factor)
         lambda_matrix.reciprocal_()
+
         storage[LAMBDA_MATRIX_NAME] = lambda_matrix.to(dtype=score_args.precondition_dtype, device="cpu").contiguous()
-        storage[NUM_LAMBDA_PROCESSED] = None
+        del storage[NUM_LAMBDA_PROCESSED]
 
     @torch.no_grad()
     def precondition_gradient(
         self,
         gradient: torch.Tensor,
-        storage: STORAGE_TYPE,
+        storage: ShardedStorage,
     ) -> torch.Tensor:
         activation_eigenvectors = storage[ACTIVATION_EIGENVECTORS_NAME].to(device=gradient.device)
         gradient_eigenvectors = storage[GRADIENT_EIGENVECTORS_NAME].to(device=gradient.device)

--- a/kronfluence/factor/covariance.py
+++ b/kronfluence/factor/covariance.py
@@ -6,7 +6,7 @@ import torch.distributed as dist
 from accelerate.utils import find_batch_size, send_to_device
 from safetensors.torch import load_file, save_file
 from torch import autocast, nn
-from torch.cuda.amp import GradScaler
+from torch.amp import GradScaler
 from torch.utils import data
 from tqdm import tqdm
 
@@ -14,7 +14,7 @@ from kronfluence.arguments import FactorArguments
 from kronfluence.module.tracked_module import ModuleMode
 from kronfluence.module.utils import (
     get_tracked_module_names,
-    load_factors,
+    load_factor_to_cpu,
     set_attention_mask,
     set_gradient_scale,
     set_mode,
@@ -197,7 +197,7 @@ def fit_covariance_matrices_with_loader(
     num_data_processed = torch.zeros((1,), dtype=torch.int64, requires_grad=False)
     enable_amp = factor_args.amp_dtype is not None
     enable_grad_scaler = enable_amp and factor_args.amp_dtype == torch.float16
-    scaler = GradScaler(init_scale=factor_args.amp_scale, enabled=enable_grad_scaler)
+    scaler = GradScaler(device=state.device.type, init_scale=factor_args.amp_scale, enabled=enable_grad_scaler)
     if enable_grad_scaler:
         gradient_scale = 1.0 / scaler.get_scale()
         set_gradient_scale(model=model, gradient_scale=gradient_scale)
@@ -244,14 +244,15 @@ def fit_covariance_matrices_with_loader(
         num_data_processed = num_data_processed.cpu()
 
     saved_factors: FACTOR_TYPE = {}
-    if state.is_main_process:
-        for factor_name in COVARIANCE_FACTOR_NAMES:
-            factor = load_factors(
-                model=model,
-                factor_name=factor_name,
-                tracked_module_names=tracked_module_names,
-                cpu=True,
-            )
+    for factor_name in COVARIANCE_FACTOR_NAMES:
+        factor = load_factor_to_cpu(
+            model=model,
+            factor_name=factor_name,
+            tracked_module_names=tracked_module_names,
+            main_process_only=True,
+            state=state,
+        )
+        if state.is_main_process:
             if len(factor) == 0:
                 raise ValueError(f"Factor `{factor_name}` has not been computed.")
             saved_factors[factor_name] = factor

--- a/kronfluence/factor/eigen.py
+++ b/kronfluence/factor/eigen.py
@@ -389,7 +389,7 @@ def fit_lambda_matrices_with_loader(
     )
     if eigen_factors is not None:
         for name in eigen_factors:
-            set_factors(model=model, factor_name=name, factors=eigen_factors[name], clone=True)
+            set_factors(model=model, factor_name=name, factors=eigen_factors[name], clone=True)  # TODO: clone=True shouldn't be needed
 
     total_steps = 0
     num_data_processed = torch.zeros((1,), dtype=torch.int64, requires_grad=False)

--- a/kronfluence/factor/eigen.py
+++ b/kronfluence/factor/eigen.py
@@ -16,7 +16,7 @@ from kronfluence.module.tracked_module import ModuleMode
 from kronfluence.module.utils import (
     finalize_iteration,
     get_tracked_module_names,
-    load_factors,
+    load_factor_to_cpu,
     set_factors,
     set_gradient_scale,
     set_mode,
@@ -441,14 +441,13 @@ def fit_lambda_matrices_with_loader(
         num_data_processed = num_data_processed.cpu()
 
     saved_factors: FACTOR_TYPE = {}
-    if state.is_main_process:
-        for factor_name in LAMBDA_FACTOR_NAMES:
-            factor = load_factors(
-                model=model,
-                factor_name=factor_name,
-                tracked_module_names=tracked_module_names,
-                cpu=True,
-            )
+    for factor_name in LAMBDA_FACTOR_NAMES:
+        factor = load_factor_to_cpu(
+            model=model,
+            factor_name=factor_name,
+            tracked_module_names=tracked_module_names,
+        )
+        if state.is_main_process:
             if len(factor) == 0:
                 raise ValueError(f"Factor `{factor_name}` has not been computed.")
             saved_factors[factor_name] = factor

--- a/kronfluence/factor/eigen.py
+++ b/kronfluence/factor/eigen.py
@@ -7,7 +7,7 @@ from accelerate.utils import find_batch_size, send_to_device
 from accelerate.utils.memory import should_reduce_batch_size
 from safetensors.torch import load_file, save_file
 from torch import autocast, nn
-from torch.cuda.amp import GradScaler
+from torch.amp import GradScaler
 from torch.utils import data
 from tqdm import tqdm
 
@@ -395,7 +395,7 @@ def fit_lambda_matrices_with_loader(
     num_data_processed = torch.zeros((1,), dtype=torch.int64, requires_grad=False)
     enable_amp = factor_args.amp_dtype is not None
     enable_grad_scaler = enable_amp and factor_args.amp_dtype == torch.float16
-    scaler = GradScaler(init_scale=factor_args.amp_scale, enabled=enable_grad_scaler)
+    scaler = GradScaler(device=state.device.type, init_scale=factor_args.amp_scale, enabled=enable_grad_scaler)
     if enable_grad_scaler:
         gradient_scale = 1.0 / scaler.get_scale()
         set_gradient_scale(model=model, gradient_scale=gradient_scale)

--- a/kronfluence/module/tracked_module.py
+++ b/kronfluence/module/tracked_module.py
@@ -194,11 +194,13 @@ class TrackedModule(nn.Module):
             device (torch.device):
                 The device to prepare the storage for.
         """
+        self.storage.materialize_all()
         FactorConfig.CONFIGS[self.factor_args.strategy].prepare(
             storage=self.storage,
             score_args=self.score_args,
             device=device,
         )
+        self.storage.dematerialize_all()
 
     def update_factor_args(self, factor_args: FactorArguments) -> None:
         """Updates the factor arguments.
@@ -267,6 +269,7 @@ class TrackedModule(nn.Module):
         del self.storage[factor_name]
         if factor_name in self.storage:
             self.storage[factor_name] = factor
+            self.storage.dematerialize_buffer(factor_name)
 
     def set_mode(self, mode: ModuleMode, release_memory: bool = False) -> None:
         """Sets the operating mode of the `TrackedModule`.

--- a/kronfluence/module/tracked_module.py
+++ b/kronfluence/module/tracked_module.py
@@ -24,9 +24,9 @@ from kronfluence.utils.constants import (
     LAMBDA_FACTOR_NAMES,
     PAIRWISE_SCORE_MATRIX_NAME,
     PRECONDITIONED_GRADIENT_NAME,
-    PRECONDITIONED_GRADIENT_TYPE,
     SELF_SCORE_VECTOR_NAME,
 )
+from kronfluence.utils.sharded_storage import ShardedStorage, BufferConfig
 
 
 class ModuleMode(str, BaseEnum):
@@ -119,31 +119,33 @@ class TrackedModule(nn.Module):
 
         self.attention_mask: Optional[torch.Tensor] = None
         self.gradient_scale: float = 1.0
-        self.storage: Dict[str, Optional[Union[torch.Tensor, PRECONDITIONED_GRADIENT_TYPE]]] = {}
         self.einsum_path: Optional[List[int]] = None
+        self.storage: ShardedStorage = ShardedStorage()
         self._initialize_storage()
 
     def _initialize_storage(self) -> None:
         """Initializes storage for various factors and scores."""
+        shard_covariance = self.factor_args.shard_covariance
+        shard_lambda = self.factor_args.shard_lambda
 
         # Storage for activation and pseudo-gradient covariance matrices #
         for covariance_factor_name in COVARIANCE_FACTOR_NAMES:
-            self.storage[covariance_factor_name]: Optional[torch.Tensor] = None
+            self.storage.register_buffer(covariance_factor_name, BufferConfig(shard=shard_covariance))
 
         # Storage for eigenvectors and eigenvalues #
         for eigen_factor_name in EIGENDECOMPOSITION_FACTOR_NAMES:
-            self.storage[eigen_factor_name]: Optional[torch.Tensor] = None
+            self.storage.register_buffer(eigen_factor_name, BufferConfig(shard=shard_covariance))
 
         # Storage for lambda matrices #
         for lambda_factor_name in LAMBDA_FACTOR_NAMES:
-            self.storage[lambda_factor_name]: Optional[torch.Tensor] = None
+            self.storage.register_buffer(lambda_factor_name, BufferConfig(shard=shard_lambda))
 
         # Storage for preconditioned gradients and influence scores #
-        self.storage[AGGREGATED_GRADIENT_NAME]: Optional[torch.Tensor] = None
-        self.storage[PRECONDITIONED_GRADIENT_NAME]: PRECONDITIONED_GRADIENT_TYPE = None
-        self.storage[ACCUMULATED_PRECONDITIONED_GRADIENT_NAME]: PRECONDITIONED_GRADIENT_TYPE = None
-        self.storage[PAIRWISE_SCORE_MATRIX_NAME]: Optional[torch.Tensor] = None
-        self.storage[SELF_SCORE_VECTOR_NAME]: Optional[torch.Tensor] = None
+        self.storage.register_buffer(AGGREGATED_GRADIENT_NAME, BufferConfig(shard=False))
+        self.storage.register_buffer(PRECONDITIONED_GRADIENT_NAME, BufferConfig(shard=False))
+        self.storage.register_buffer(ACCUMULATED_PRECONDITIONED_GRADIENT_NAME, BufferConfig(shard=False))
+        self.storage.register_buffer(PAIRWISE_SCORE_MATRIX_NAME, BufferConfig(shard=False))
+        self.storage.register_buffer(SELF_SCORE_VECTOR_NAME, BufferConfig(shard=False))
 
     def forward(self, inputs: torch.Tensor, *args: Any, **kwargs: Any) -> torch.Tensor:
         """Performs a forward pass of the tracked module.

--- a/kronfluence/module/tracked_module.py
+++ b/kronfluence/module/tracked_module.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 import torch
 from accelerate.utils.dataclasses import BaseEnum
 from torch import nn
+from torch.distributed.tensor import DTensor
 
 from kronfluence.arguments import FactorArguments, ScoreArguments
 from kronfluence.factor.config import FactorConfig
@@ -19,9 +20,11 @@ from kronfluence.module.tracker.self_score import (
 from kronfluence.utils.constants import (
     ACCUMULATED_PRECONDITIONED_GRADIENT_NAME,
     AGGREGATED_GRADIENT_NAME,
-    COVARIANCE_FACTOR_NAMES,
+    COVARIANCE_COUNTER_NAMES,
+    COVARIANCE_MATRIX_NAMES,
     EIGENDECOMPOSITION_FACTOR_NAMES,
-    LAMBDA_FACTOR_NAMES,
+    LAMBDA_MATRIX_NAME,
+    NUM_LAMBDA_PROCESSED,
     PAIRWISE_SCORE_MATRIX_NAME,
     PRECONDITIONED_GRADIENT_NAME,
     SELF_SCORE_VECTOR_NAME,
@@ -121,31 +124,44 @@ class TrackedModule(nn.Module):
         self.gradient_scale: float = 1.0
         self.einsum_path: Optional[List[int]] = None
         self.storage: ShardedStorage = ShardedStorage()
-        self._initialize_storage()
+        self._configure_storage()
 
-    def _initialize_storage(self) -> None:
-        """Initializes storage for various factors and scores."""
+
+    def _configure_factor_storage(self) -> None:
+        """Initializes storage for various factors."""
         shard_covariance = self.factor_args.shard_covariance
+        shard_eigen_decomp = self.factor_args.shard_eigendecomposition
         shard_lambda = self.factor_args.shard_lambda
 
         # Storage for activation and pseudo-gradient covariance matrices #
-        for covariance_factor_name in COVARIANCE_FACTOR_NAMES:
+        for covariance_factor_name in COVARIANCE_MATRIX_NAMES:
             self.storage.register_buffer(covariance_factor_name, BufferConfig(shard=shard_covariance))
+
+        for covariance_counter_name in COVARIANCE_COUNTER_NAMES:
+            self.storage.register_buffer(covariance_counter_name, BufferConfig(shard=False))
 
         # Storage for eigenvectors and eigenvalues #
         for eigen_factor_name in EIGENDECOMPOSITION_FACTOR_NAMES:
-            self.storage.register_buffer(eigen_factor_name, BufferConfig(shard=shard_covariance))
+            self.storage.register_buffer(eigen_factor_name, BufferConfig(shard=shard_eigen_decomp))
 
         # Storage for lambda matrices #
-        for lambda_factor_name in LAMBDA_FACTOR_NAMES:
-            self.storage.register_buffer(lambda_factor_name, BufferConfig(shard=shard_lambda))
+        self.storage.register_buffer(LAMBDA_MATRIX_NAME, BufferConfig(shard=shard_lambda))
+        self.storage.register_buffer(NUM_LAMBDA_PROCESSED, BufferConfig(shard=False))
 
-        # Storage for preconditioned gradients and influence scores #
+
+    def _configure_score_storage(self) -> None:
+        """Initializes storage for various scores."""
+         # Storage for preconditioned gradients and influence scores #
         self.storage.register_buffer(AGGREGATED_GRADIENT_NAME, BufferConfig(shard=False))
         self.storage.register_buffer(PRECONDITIONED_GRADIENT_NAME, BufferConfig(shard=False))
         self.storage.register_buffer(ACCUMULATED_PRECONDITIONED_GRADIENT_NAME, BufferConfig(shard=False))
         self.storage.register_buffer(PAIRWISE_SCORE_MATRIX_NAME, BufferConfig(shard=False))
         self.storage.register_buffer(SELF_SCORE_VECTOR_NAME, BufferConfig(shard=False))
+
+    def _configure_storage(self) -> None:
+        """Initializes storage for various factors and scores."""
+        self._configure_factor_storage()
+        self._configure_score_storage()
 
     def forward(self, inputs: torch.Tensor, *args: Any, **kwargs: Any) -> torch.Tensor:
         """Performs a forward pass of the tracked module.
@@ -192,6 +208,7 @@ class TrackedModule(nn.Module):
                 New factor arguments to set.
         """
         self.factor_args = factor_args
+        self._configure_factor_storage()
 
     def update_score_args(self, score_args: ScoreArguments) -> None:
         """Updates the score arguments.
@@ -201,9 +218,10 @@ class TrackedModule(nn.Module):
                 New score arguments to set.
         """
         self.score_args = score_args
+        self._configure_score_storage()
 
     def get_factor(self, factor_name: str) -> Optional[torch.Tensor]:
-        """Retrieves a factor by name from storage.
+        """Retrieves a copy of a factor by name from storage.
 
         Args:
             factor_name (str):
@@ -213,9 +231,20 @@ class TrackedModule(nn.Module):
             Optional[torch.Tensor]:
                 The requested factor, or `None` if not found.
         """
-        if factor_name not in self.storage or self.storage[factor_name] is None:
+        if not self.storage.is_initialized(factor_name):
             return None
-        return self.storage[factor_name]
+        if self.storage.is_materialized(factor_name):
+            tensor = self.storage[factor_name]
+            if isinstance(tensor, DTensor):
+                tensor = tensor.to_local()
+            return tensor.clone()
+        else:
+            self.storage.materialize_buffer(factor_name)
+            tensor = self.storage[factor_name]
+            if isinstance(tensor, DTensor):
+                tensor = tensor.to_local()
+            self.storage.dematerialize_buffer(factor_name)
+            return tensor.clone()
 
     def release_factor(self, factor_name: str) -> None:
         """Releases a factor from memory.
@@ -224,10 +253,7 @@ class TrackedModule(nn.Module):
             factor_name (str):
                 The name of the factor to release.
         """
-        if factor_name not in self.storage or self.storage[factor_name] is None:
-            return None
         del self.storage[factor_name]
-        self.storage[factor_name] = None
 
     def set_factor(self, factor_name: str, factor: Any) -> None:
         """Sets a factor in storage.

--- a/kronfluence/module/tracked_module.py
+++ b/kronfluence/module/tracked_module.py
@@ -264,6 +264,7 @@ class TrackedModule(nn.Module):
             factor (Any):
                 The factor value to store.
         """
+        del self.storage[factor_name]
         if factor_name in self.storage:
             self.storage[factor_name] = factor
 

--- a/kronfluence/module/tracker/factor.py
+++ b/kronfluence/module/tracker/factor.py
@@ -159,8 +159,9 @@ class LambdaTracker(BaseTracker):
 
     def _eigendecomposition_results_exist(self) -> bool:
         """Checks if eigendecomposition results are available."""
+        storage: ShardedStorage = self.module.storage
         for eigen_factor_name in EIGENDECOMPOSITION_FACTOR_NAMES:
-            if self.module.storage[eigen_factor_name] is None:
+            if not storage.is_initialized(eigen_factor_name):
                 return False
         return True
 
@@ -173,66 +174,63 @@ class LambdaTracker(BaseTracker):
         """
         batch_size = per_sample_gradient.size(0)
 
-        if self.module.storage[NUM_LAMBDA_PROCESSED] is None:
-            self.module.storage[NUM_LAMBDA_PROCESSED] = torch.zeros(
+        storage: ShardedStorage = self.module.storage
+        requires_eig = FactorConfig.CONFIGS[self.module.factor_args.strategy].requires_eigendecomposition_for_lambda
+
+        if not storage.is_initialized(NUM_LAMBDA_PROCESSED):
+            storage[NUM_LAMBDA_PROCESSED] = torch.zeros(
                 size=(1,),
                 dtype=torch.int64,
                 requires_grad=False,
             )
-            self.module.storage[LAMBDA_MATRIX_NAME] = torch.zeros(
+            storage[LAMBDA_MATRIX_NAME] = torch.zeros(
                 size=(per_sample_gradient.size(1), per_sample_gradient.size(2)),
                 dtype=per_sample_gradient.dtype,
                 device=per_sample_gradient.device,
                 requires_grad=False,
             )
 
-            if FactorConfig.CONFIGS[self.module.factor_args.strategy].requires_eigendecomposition_for_lambda:
+            if requires_eig:
                 if not self._eigendecomposition_results_exist():
                     raise FactorsNotFoundError(
                         f"The strategy {self.module.factor_args.strategy} requires eigendecomposition "
                         f"results for Lambda computations, but they are not found."
                     )
+            storage.dematerialize_all()
 
-                # Move activation and pseudo-gradient eigenvectors to appropriate devices.
-                self.module.storage[ACTIVATION_EIGENVECTORS_NAME] = self.module.storage[
-                    ACTIVATION_EIGENVECTORS_NAME
-                ].to(
-                    dtype=per_sample_gradient.dtype,
-                    device=per_sample_gradient.device,
-                )
-                self.module.storage[GRADIENT_EIGENVECTORS_NAME] = self.module.storage[GRADIENT_EIGENVECTORS_NAME].to(
-                    dtype=per_sample_gradient.dtype,
-                    device=per_sample_gradient.device,
-                )
+        storage[NUM_LAMBDA_PROCESSED].add_(batch_size)
 
-        self.module.storage[NUM_LAMBDA_PROCESSED].add_(batch_size)
-        if FactorConfig.CONFIGS[self.module.factor_args.strategy].requires_eigendecomposition_for_lambda:
+        if requires_eig:
+            storage.materialize_buffer(ACTIVATION_EIGENVECTORS_NAME) # TODO: Overlap communication with computation better!
+            storage.materialize_buffer(GRADIENT_EIGENVECTORS_NAME)
             if self.module.factor_args.use_iterative_lambda_aggregation:
                 # This batch-wise iterative update can be useful when the GPU memory is limited.
                 per_sample_gradient = torch.matmul(
                     per_sample_gradient,
-                    self.module.storage[ACTIVATION_EIGENVECTORS_NAME],
+                    storage[ACTIVATION_EIGENVECTORS_NAME],
                 )
                 for i in range(batch_size):
                     sqrt_lambda = torch.matmul(
-                        self.module.storage[GRADIENT_EIGENVECTORS_NAME].t(),
+                        storage[GRADIENT_EIGENVECTORS_NAME].t(),
                         per_sample_gradient[i],
                     )
-                    self.module.storage[LAMBDA_MATRIX_NAME].add_(sqrt_lambda.square_())
+                    storage.accumulate(LAMBDA_MATRIX_NAME, sqrt_lambda.square_())
             else:
                 per_sample_gradient = (
                     torch.matmul(
-                        self.module.storage[GRADIENT_EIGENVECTORS_NAME].t(),
-                        torch.matmul(per_sample_gradient, self.module.storage[ACTIVATION_EIGENVECTORS_NAME]),
+                        storage[GRADIENT_EIGENVECTORS_NAME].t(),
+                        torch.matmul(per_sample_gradient, storage[ACTIVATION_EIGENVECTORS_NAME]),
                     )
                     .square_()
                     .sum(dim=0)
                 )
-                self.module.storage[LAMBDA_MATRIX_NAME].add_(per_sample_gradient)
+                storage.accumulate(LAMBDA_MATRIX_NAME, per_sample_gradient)
+            storage.dematerialize_buffer(ACTIVATION_EIGENVECTORS_NAME)
+            storage.dematerialize_buffer(GRADIENT_EIGENVECTORS_NAME)
         else:
             # Approximate the eigenbasis as identity.
             per_sample_gradient = per_sample_gradient.square_().sum(dim=0)
-            self.module.storage[LAMBDA_MATRIX_NAME].add_(per_sample_gradient)
+            storage.accumulate(LAMBDA_MATRIX_NAME, per_sample_gradient)
 
     def register_hooks(self) -> None:
         """Sets up hooks to compute lambda matrices."""
@@ -308,19 +306,24 @@ class LambdaTracker(BaseTracker):
 
     def exist(self) -> bool:
         """Checks if Lambda matrices are available."""
+        storage: ShardedStorage = self.module.storage
         for lambda_factor_name in LAMBDA_FACTOR_NAMES:
-            if self.module.storage[lambda_factor_name] is None:
+            if not storage.is_initialized(lambda_factor_name):
                 return False
         return True
 
     def synchronize(self, num_processes: int) -> None:
         """Aggregates Lambda matrices across multiple devices or nodes in a distributed setting."""
         del num_processes
+        storage: ShardedStorage = self.module.storage
         if dist.is_initialized() and torch.cuda.is_available() and self.exist():
             for lambda_factor_name in LAMBDA_FACTOR_NAMES:
-                self.module.storage[lambda_factor_name] = self.module.storage[lambda_factor_name].cuda()
+                if storage.buffer_configs[lambda_factor_name].shard:
+                    continue # Already syncronized
+
+                storage[lambda_factor_name] = storage[lambda_factor_name].cuda()
                 dist.reduce(
-                    tensor=self.module.storage[lambda_factor_name],
+                    tensor=storage[lambda_factor_name],
                     op=dist.ReduceOp.SUM,
                     dst=0,
                 )

--- a/kronfluence/module/tracker/factor.py
+++ b/kronfluence/module/tracker/factor.py
@@ -20,13 +20,11 @@ from kronfluence.utils.constants import (
     NUM_LAMBDA_PROCESSED,
 )
 from kronfluence.utils.exceptions import FactorsNotFoundError
+from kronfluence.utils.sharded_storage import ShardedStorage
 
 
 class CovarianceTracker(BaseTracker):
     """Tracks and computes activation and gradient covariance matrices for a given module."""
-
-    _activation_covariance_initialized: bool = False
-    _gradient_covariance_initialized: bool = False
 
     def _update_activation_covariance_matrix(
         self, input_activation: torch.Tensor, count: Union[torch.Tensor, int]
@@ -39,23 +37,24 @@ class CovarianceTracker(BaseTracker):
             count (int):
                 The number of activations.
         """
-        if not self._activation_covariance_initialized:
-            self.module.storage[NUM_ACTIVATION_COVARIANCE_PROCESSED] = torch.zeros(
+        storage: ShardedStorage = self.module.storage
+        if not storage.is_initialized(ACTIVATION_COVARIANCE_MATRIX_NAME):
+            storage[NUM_ACTIVATION_COVARIANCE_PROCESSED] = torch.zeros(
                 size=(1,),
                 dtype=torch.int64,
                 device=count.device if isinstance(count, torch.Tensor) else None,
                 requires_grad=False,
             )
             dimension = input_activation.size(1)
-            self.module.storage[ACTIVATION_COVARIANCE_MATRIX_NAME] = torch.zeros(
+            storage[ACTIVATION_COVARIANCE_MATRIX_NAME] = torch.zeros(
                 size=(dimension, dimension),
                 dtype=input_activation.dtype,
                 device=input_activation.device,
                 requires_grad=False,
             )
-            self._activation_covariance_initialized = True
-        self.module.storage[NUM_ACTIVATION_COVARIANCE_PROCESSED].add_(count)
-        self.module.storage[ACTIVATION_COVARIANCE_MATRIX_NAME].addmm_(input_activation.t(), input_activation)
+            storage.dematerialize_all()
+        storage[NUM_ACTIVATION_COVARIANCE_PROCESSED] += count
+        storage.accumulate(ACTIVATION_COVARIANCE_MATRIX_NAME, input_activation.t() @ input_activation)
 
     def _update_gradient_covariance_matrix(
         self, output_gradient: torch.Tensor, count: Union[torch.Tensor, int]
@@ -69,28 +68,30 @@ class CovarianceTracker(BaseTracker):
             count (int):
                 The number of gradients.
         """
-        if not self._gradient_covariance_initialized:
+        storage: ShardedStorage = self.module.storage
+        if not storage.is_initialized(GRADIENT_COVARIANCE_MATRIX_NAME):
             # In most cases, `NUM_GRADIENT_COVARIANCE_PROCESSED` and `NUM_ACTIVATION_COVARIANCE_PROCESSED` are
             # identical. However, they may differ when using gradient checkpointing or `torch.compile()`.
-            self.module.storage[NUM_GRADIENT_COVARIANCE_PROCESSED] = torch.zeros(
+            storage[NUM_GRADIENT_COVARIANCE_PROCESSED] = torch.zeros(
                 size=(1,),
                 dtype=torch.int64,
                 device=count.device if isinstance(count, torch.Tensor) else None,
                 requires_grad=False,
             )
             dimension = output_gradient.size(1)
-            self.module.storage[GRADIENT_COVARIANCE_MATRIX_NAME] = torch.zeros(
+            storage[GRADIENT_COVARIANCE_MATRIX_NAME] = torch.zeros(
                 size=(dimension, dimension),
                 dtype=output_gradient.dtype,
                 device=output_gradient.device,
                 requires_grad=False,
             )
-            self._gradient_covariance_initialized = True
-        self.module.storage[NUM_GRADIENT_COVARIANCE_PROCESSED].add_(count)
+            storage.dematerialize_all()
+        storage[NUM_GRADIENT_COVARIANCE_PROCESSED] += count
         alpha = 1
         if self.module.gradient_scale != 1.0:
             alpha = self.module.gradient_scale**2.0
-        self.module.storage[GRADIENT_COVARIANCE_MATRIX_NAME].addmm_(output_gradient.t(), output_gradient, alpha=alpha)
+        output_gradient = alpha * output_gradient
+        storage.accumulate(GRADIENT_COVARIANCE_MATRIX_NAME, output_gradient.t() @ output_gradient)
 
     def register_hooks(self) -> None:
         """Sets up hooks to compute activation and gradient covariance matrices."""
@@ -124,29 +125,33 @@ class CovarianceTracker(BaseTracker):
 
     def exist(self) -> bool:
         """Checks if both activation and gradient covariance matrices are available."""
+        storage: ShardedStorage = self.module.storage
         for covariance_factor_name in COVARIANCE_FACTOR_NAMES:
-            if self.module.storage[covariance_factor_name] is None:
+            if not storage.is_initialized(covariance_factor_name):
                 return False
         return True
 
     def synchronize(self, num_processes: int) -> None:
         """Aggregates covariance matrices across multiple devices or nodes in a distributed setting."""
         del num_processes
+        storage: ShardedStorage = self.module.storage
         if dist.is_initialized() and torch.cuda.is_available() and self.exist():
             for covariance_factor_name in COVARIANCE_FACTOR_NAMES:
-                self.module.storage[covariance_factor_name] = self.module.storage[covariance_factor_name].cuda()
+                if storage.buffer_configs[covariance_factor_name].shard:
+                    continue # Already syncronized
+
+                storage[covariance_factor_name] = storage[covariance_factor_name].cuda()
                 dist.reduce(
-                    tensor=self.module.storage[covariance_factor_name],
+                    tensor=storage[covariance_factor_name],
                     op=dist.ReduceOp.SUM,
                     dst=0,
                 )
 
     def release_memory(self) -> None:
         """Clears all covariance matrices from memory."""
-        self._activation_covariance_initialized = False
-        self._gradient_covariance_initialized = False
+        storage: ShardedStorage = self.module.storage
         for covariance_factor_name in COVARIANCE_FACTOR_NAMES:
-            self.module.storage[covariance_factor_name] = None
+            del storage[covariance_factor_name]
 
 
 class LambdaTracker(BaseTracker):

--- a/kronfluence/module/tracker/pairwise_score.py
+++ b/kronfluence/module/tracker/pairwise_score.py
@@ -110,7 +110,7 @@ class PairwiseScoreTracker(BaseTracker):
 
     def exist(self) -> bool:
         """Checks if pairwise score is available."""
-        return self.module.storage[PAIRWISE_SCORE_MATRIX_NAME] is not None
+        return self.module.storage.is_initialized(PAIRWISE_SCORE_MATRIX_NAME)
 
     def accumulate_iterations(self) -> None:
         """Removes pairwise scores from memory after a single iteration."""
@@ -120,18 +120,18 @@ class PairwiseScoreTracker(BaseTracker):
     def finalize_all_iterations(self) -> None:
         """Removes cached preconditioned gradient from memory. Additionally, if aggregated gradients are available,
         computes the pairwise score using them."""
-        if self.module.storage[AGGREGATED_GRADIENT_NAME] is not None:
+        if self.module.storage.is_initialized(AGGREGATED_GRADIENT_NAME):
             self.module.storage[AGGREGATED_GRADIENT_NAME] = self.module.storage[AGGREGATED_GRADIENT_NAME].to(
                 dtype=self.module.score_args.score_dtype
             )
             self._compute_pairwise_score_with_gradient(
                 per_sample_gradient=self.module.storage[AGGREGATED_GRADIENT_NAME]
             )
-        self.module.storage[ACCUMULATED_PRECONDITIONED_GRADIENT_NAME] = None
-        self.module.storage[PRECONDITIONED_GRADIENT_NAME] = None
+        del self.module.storage[ACCUMULATED_PRECONDITIONED_GRADIENT_NAME]
+        del self.module.storage[PRECONDITIONED_GRADIENT_NAME]
         self.clear_all_cache()
 
     def release_memory(self) -> None:
         """Releases pairwise scores from memory."""
         self.clear_all_cache()
-        self.module.storage[PAIRWISE_SCORE_MATRIX_NAME] = None
+        del self.module.storage[PAIRWISE_SCORE_MATRIX_NAME]

--- a/kronfluence/module/tracker/precondition.py
+++ b/kronfluence/module/tracker/precondition.py
@@ -103,6 +103,7 @@ class PreconditionTracker(BaseTracker):
         def backward_hook(output_gradient: torch.Tensor) -> None:
             if self.cached_activations is None:
                 self._raise_cache_not_found_exception()
+            self.module.storage.materialize_all()
             handle = self.cached_hooks.pop()
             handle.remove()
             output_gradient = output_gradient.detach().to(dtype=self.module.score_args.per_sample_gradient_dtype)
@@ -121,6 +122,7 @@ class PreconditionTracker(BaseTracker):
                 preconditioned_gradient.mul_(self.module.gradient_scale)
             del per_sample_gradient
             self._process_preconditioned_gradient(preconditioned_gradient=preconditioned_gradient)
+            self.module.storage.dematerialize_all()
 
         @torch.no_grad()
         def shared_backward_hook(output_gradient: torch.Tensor) -> None:
@@ -143,6 +145,7 @@ class PreconditionTracker(BaseTracker):
     def finalize_iteration(self) -> None:
         """Computes preconditioned gradient using cached per-sample gradients."""
         if self.module.factor_args.has_shared_parameters:
+            self.module.storage.materialize_all()
             self.cached_per_sample_gradient = self.cached_per_sample_gradient.to(
                 dtype=self.module.score_args.precondition_dtype
             )
@@ -154,6 +157,7 @@ class PreconditionTracker(BaseTracker):
             if self.module.gradient_scale != 1.0:
                 preconditioned_gradient.mul_(self.module.gradient_scale)
             self._process_preconditioned_gradient(preconditioned_gradient=preconditioned_gradient)
+            self.module.storage.dematerialize_all()
         self.clear_all_cache()
 
     def exist(self) -> bool:
@@ -242,7 +246,8 @@ class PreconditionTracker(BaseTracker):
     @torch.no_grad()
     def finalize_all_iterations(self) -> None:
         """Preconditions aggregated gradient if it exists in storage."""
-        if self.module.storage[AGGREGATED_GRADIENT_NAME] is not None:
+        if self.module.storage.is_initialized(AGGREGATED_GRADIENT_NAME):
+            self.module.storage.materialize_all()
             self.module.storage[AGGREGATED_GRADIENT_NAME] = self.module.storage[AGGREGATED_GRADIENT_NAME].to(
                 dtype=self.module.score_args.precondition_dtype
             )
@@ -250,12 +255,13 @@ class PreconditionTracker(BaseTracker):
                 gradient=self.module.storage[AGGREGATED_GRADIENT_NAME],
                 storage=self.module.storage,
             )
-            self.module.storage[AGGREGATED_GRADIENT_NAME] = None
+            del self.module.storage[AGGREGATED_GRADIENT_NAME]
             self._process_preconditioned_gradient(preconditioned_gradient=preconditioned_gradient)
             self.accumulate_iterations()
+            self.module.storage.dematerialize_all()
 
     def release_memory(self) -> None:
         """Clears preconditioned gradients from memory."""
-        self.module.storage[ACCUMULATED_PRECONDITIONED_GRADIENT_NAME] = None
-        self.module.storage[PRECONDITIONED_GRADIENT_NAME] = None
+        del self.module.storage[ACCUMULATED_PRECONDITIONED_GRADIENT_NAME]
+        del self.module.storage[PRECONDITIONED_GRADIENT_NAME]
         self.clear_all_cache()

--- a/kronfluence/module/tracker/precondition.py
+++ b/kronfluence/module/tracker/precondition.py
@@ -49,7 +49,7 @@ class PreconditionTracker(BaseTracker):
         U, S, V = torch.svd_lowrank(preconditioned_gradient, q=rank)
         left_mat = torch.matmul(U, torch.diag_embed(S)).to(dtype=target_dtype)
         V = V.transpose(1, 2).to(dtype=target_dtype)
-        return [left_mat, V]
+        return [left_mat, V]  # TODO (lev): this should be a dataclass or a namedtuple.
 
     def _process_preconditioned_gradient(self, preconditioned_gradient: torch.Tensor) -> None:
         """Processes the preconditioned per-sample gradient.

--- a/kronfluence/module/tracker/self_score.py
+++ b/kronfluence/module/tracker/self_score.py
@@ -11,28 +11,8 @@ from kronfluence.utils.constants import (
 )
 
 
-def move_storage_to_device(storage: STORAGE_TYPE, target_device: torch.device) -> None:
-    """Moves all stored factors in the storage dictionary to the specified target device.
-
-    Args:
-        storage (STORAGE_TYPE):
-            A dictionary containing stored factors.
-        target_device (torch.device):
-            The target device to move the factors to.
-    """
-    for name, factor in storage.items():
-        if factor is not None:
-            if isinstance(factor, list):
-                for i in range(len(storage[name])):
-                    storage[name][i] = factor[i].to(device=target_device)
-            if isinstance(factor, torch.Tensor):
-                storage[name] = factor.to(device=target_device)
-
-
 class SelfScoreTracker(BaseTracker):
     """Computes self-influence scores for a given module."""
-
-    storage_at_device: bool = False
 
     def _compute_self_score(self, per_sample_gradient: torch.Tensor) -> None:
         """Computes self-influence scores using per-sample gradients.
@@ -41,12 +21,6 @@ class SelfScoreTracker(BaseTracker):
             per_sample_gradient (torch.Tensor):
                 The per-sample gradient tensor for the given batch.
         """
-        if not self.storage_at_device:
-            move_storage_to_device(
-                storage=self.module.storage,
-                target_device=per_sample_gradient.device,
-            )
-            self.storage_at_device = True
 
         preconditioned_gradient = (
             FactorConfig.CONFIGS[self.module.factor_args.strategy]
@@ -141,17 +115,12 @@ class SelfScoreTracker(BaseTracker):
     def release_memory(self) -> None:
         """Releases self-influence scores from memory."""
         self.clear_all_cache()
-        if self.storage_at_device:
-            move_storage_to_device(storage=self.module.storage, target_device=torch.device("cpu"))
-        self.storage_at_device = False
         del self.module.storage[SELF_SCORE_VECTOR_NAME]
         self.module.storage[SELF_SCORE_VECTOR_NAME] = None
 
 
 class SelfScoreWithMeasurementTracker(BaseTracker):
     """Computes self-influence scores with measurement for a given module."""
-
-    storage_at_device: bool = False
 
     def _compute_self_measurement_score_with_gradient(self, per_sample_gradient: torch.Tensor) -> None:
         """Computes self-influence scores with measurement using per-sample-gradients.
@@ -192,13 +161,6 @@ class SelfScoreWithMeasurementTracker(BaseTracker):
         def backward_hook(output_gradient: torch.Tensor) -> None:
             if self.cached_activations is None:
                 self._raise_cache_not_found_exception()
-
-            if not self.storage_at_device:
-                move_storage_to_device(
-                    storage=self.module.storage,
-                    target_device=output_gradient.device,
-                )
-                self.storage_at_device = True
 
             handle = self.cached_hooks.pop()
             handle.remove()
@@ -248,8 +210,5 @@ class SelfScoreWithMeasurementTracker(BaseTracker):
     def release_memory(self) -> None:
         """Releases self-influence scores from memory."""
         self.clear_all_cache()
-        if self.storage_at_device:
-            move_storage_to_device(storage=self.module.storage, target_device=torch.device("cpu"))
-        self.storage_at_device = False
         del self.module.storage[SELF_SCORE_VECTOR_NAME]
         self.module.storage[SELF_SCORE_VECTOR_NAME] = None

--- a/kronfluence/module/tracker/self_score.py
+++ b/kronfluence/module/tracker/self_score.py
@@ -3,7 +3,7 @@ from typing import Tuple
 import torch
 from torch import nn
 
-from kronfluence.factor.config import STORAGE_TYPE, FactorConfig
+from kronfluence.factor.config import FactorConfig
 from kronfluence.module.tracker.base import BaseTracker
 from kronfluence.utils.constants import (
     PRECONDITIONED_GRADIENT_NAME,
@@ -21,7 +21,7 @@ class SelfScoreTracker(BaseTracker):
             per_sample_gradient (torch.Tensor):
                 The per-sample gradient tensor for the given batch.
         """
-
+        self.module.storage.materialize_all()
         preconditioned_gradient = (
             FactorConfig.CONFIGS[self.module.factor_args.strategy]
             .precondition_gradient(
@@ -33,6 +33,7 @@ class SelfScoreTracker(BaseTracker):
         per_sample_gradient = per_sample_gradient.to(dtype=self.module.score_args.score_dtype)
         preconditioned_gradient.mul_(per_sample_gradient)
         self.module.storage[SELF_SCORE_VECTOR_NAME] = preconditioned_gradient.sum(dim=(1, 2))
+        self.module.storage.demateralize_all()
 
     def register_hooks(self) -> None:
         """Sets up hooks to compute self-influence scores."""
@@ -106,7 +107,7 @@ class SelfScoreTracker(BaseTracker):
 
     def exist(self) -> bool:
         """Checks if self-influence score is available."""
-        return self.module.storage[SELF_SCORE_VECTOR_NAME] is not None
+        return self.module.storage.is_initialized(SELF_SCORE_VECTOR_NAME)
 
     def accumulate_iterations(self) -> None:
         """Removes self-influence scores from memory after a single iteration."""
@@ -116,7 +117,6 @@ class SelfScoreTracker(BaseTracker):
         """Releases self-influence scores from memory."""
         self.clear_all_cache()
         del self.module.storage[SELF_SCORE_VECTOR_NAME]
-        self.module.storage[SELF_SCORE_VECTOR_NAME] = None
 
 
 class SelfScoreWithMeasurementTracker(BaseTracker):
@@ -201,7 +201,7 @@ class SelfScoreWithMeasurementTracker(BaseTracker):
 
     def exist(self) -> bool:
         """Checks if self-influence score is available."""
-        return self.module.storage[SELF_SCORE_VECTOR_NAME] is not None
+        return self.module.storage.is_initialized(SELF_SCORE_VECTOR_NAME)
 
     def accumulate_iterations(self) -> None:
         """Removes self-influence scores from memory after a single iteration."""
@@ -211,4 +211,3 @@ class SelfScoreWithMeasurementTracker(BaseTracker):
         """Releases self-influence scores from memory."""
         self.clear_all_cache()
         del self.module.storage[SELF_SCORE_VECTOR_NAME]
-        self.module.storage[SELF_SCORE_VECTOR_NAME] = None

--- a/kronfluence/module/tracker/self_score.py
+++ b/kronfluence/module/tracker/self_score.py
@@ -33,7 +33,7 @@ class SelfScoreTracker(BaseTracker):
         per_sample_gradient = per_sample_gradient.to(dtype=self.module.score_args.score_dtype)
         preconditioned_gradient.mul_(per_sample_gradient)
         self.module.storage[SELF_SCORE_VECTOR_NAME] = preconditioned_gradient.sum(dim=(1, 2))
-        self.module.storage.demateralize_all()
+        self.module.storage.dematerialize_all()
 
     def register_hooks(self) -> None:
         """Sets up hooks to compute self-influence scores."""

--- a/kronfluence/module/utils.py
+++ b/kronfluence/module/utils.py
@@ -9,6 +9,7 @@ from torch.nn.parallel.distributed import DistributedDataParallel as DDP
 from kronfluence.arguments import FactorArguments, ScoreArguments
 from kronfluence.module.tracked_module import ModuleMode, TrackedModule
 from kronfluence.task import Task
+from kronfluence.utils.state import State
 from kronfluence.utils.exceptions import IllegalTaskConfigurationError
 
 
@@ -198,11 +199,12 @@ def get_tracked_module_names(model: nn.Module) -> List[str]:
     return [module.name for module in model.modules() if isinstance(module, TrackedModule)]
 
 
-def load_factors(
+def load_factor_to_cpu(
     model: nn.Module,
     factor_name: str,
     tracked_module_names: List[str] = None,
-    cpu: bool = True,
+    main_process_only: bool = True,
+    state: State | None = None,
 ) -> Dict[str, torch.Tensor]:
     """Loads factors with the given name from specified `TrackedModule` instances.
 
@@ -213,13 +215,14 @@ def load_factors(
             The name of the factor to load.
         tracked_module_names (Optional[List[str]]):
             Names of modules to load from. If `None`, loads from all.
-        cpu (bool):
-            If `True`, moves factors to CPU and releases GPU memory.
+        main_process_only (bool):
+            If `True`, only loads factors onto the CPU on the main process.
 
     Returns:
         Dict[str, torch.Tensor]:
             A dictionary of loaded factors, keyed by module name.
     """
+    state = State() if state is None else state
     loaded_factors = {}
     for module in model.modules():
         if isinstance(module, TrackedModule):
@@ -227,11 +230,10 @@ def load_factors(
                 continue
             factor = module.get_factor(factor_name=factor_name)
             if factor is not None:
-                if cpu:
-                    loaded_factors[module.name] = factor.to(device="cpu", copy=True)
-                    module.release_factor(factor_name=factor_name)
-                else:
-                    loaded_factors[module.name] = factor
+                loaded_factors[module.name] = factor.to(device="cpu", copy=True)
+                module.release_factor(factor_name=factor_name)
+            if main_process_only and not state.is_main_process:
+                del loaded_factors[module.name]
     return loaded_factors
 
 

--- a/kronfluence/score/self.py
+++ b/kronfluence/score/self.py
@@ -6,7 +6,7 @@ import torch.distributed as dist
 from accelerate.utils import send_to_device
 from safetensors.torch import load_file, save_file
 from torch import autocast, nn
-from torch.cuda.amp import GradScaler
+from torch.amp import GradScaler
 from torch.utils import data
 from tqdm import tqdm
 
@@ -202,7 +202,7 @@ def compute_self_scores_with_loaders(
     total_steps = 0
     enable_amp = score_args.amp_dtype is not None
     enable_grad_scaler = enable_amp and factor_args.amp_dtype == torch.float16
-    scaler = GradScaler(init_scale=factor_args.amp_scale, enabled=enable_grad_scaler)
+    scaler = GradScaler(device=state.device.type, init_scale=factor_args.amp_scale, enabled=enable_grad_scaler)
     if enable_grad_scaler:
         gradient_scale = 1.0 / scaler.get_scale()
         set_gradient_scale(model=model, gradient_scale=gradient_scale)

--- a/kronfluence/utils/constants.py
+++ b/kronfluence/utils/constants.py
@@ -30,12 +30,20 @@ NUM_ACTIVATION_COVARIANCE_PROCESSED = "num_activation_covariance_processed"
 NUM_GRADIENT_COVARIANCE_PROCESSED = "num_gradient_covariance_processed"
 
 
-# A list of factors to keep track of when computing covariance matrices.
-COVARIANCE_FACTOR_NAMES = [
+COVARIANCE_MATRIX_NAMES = [
     ACTIVATION_COVARIANCE_MATRIX_NAME,
     GRADIENT_COVARIANCE_MATRIX_NAME,
+]
+
+COVARIANCE_COUNTER_NAMES = [
     NUM_ACTIVATION_COVARIANCE_PROCESSED,
     NUM_GRADIENT_COVARIANCE_PROCESSED,
+]
+
+# A list of factors to keep track of when computing covariance matrices.
+COVARIANCE_FACTOR_NAMES = [
+    *COVARIANCE_MATRIX_NAMES,
+    *COVARIANCE_COUNTER_NAMES,
 ]
 
 

--- a/kronfluence/utils/model.py
+++ b/kronfluence/utils/model.py
@@ -4,13 +4,7 @@ from typing import Optional
 import torch
 import torch.distributed as dist
 from torch import nn
-from torch.distributed.fsdp import CPUOffload
-from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-from torch.distributed.fsdp import ShardingStrategy
-from torch.distributed.fsdp.wrap import (
-    size_based_auto_wrap_policy,
-    transformer_auto_wrap_policy,
-)
+from torch.distributed.fsdp import fully_shard, OffloadPolicy, CPUOffloadPolicy, FSDPModule
 from torch.nn.parallel.distributed import DistributedDataParallel
 
 
@@ -60,12 +54,9 @@ def apply_fsdp(
     local_rank: int,
     rank: int,
     world_size: int,
-    sharding_strategy: str = "FULL_SHARD",
     cpu_offload: bool = True,
-    is_transformer: bool = False,
-    layer_to_wrap: Optional[nn.Module] = None,
-) -> FSDP:
-    """Applies FullyShardedDataParallel (FSDP) to the given PyTorch model.
+) -> FSDPModule:
+    """Applies FSDP2 to the given PyTorch model.
 
     Args:
         model (nn.Module):
@@ -76,14 +67,8 @@ def apply_fsdp(
             The global rank of the current process across all nodes.
         world_size (int):
             The total number of processes in the distributed setup.
-        sharding_strategy (str):
-            The FSDP sharding strategy to use. Defaults to "FULL_SHARD".
         cpu_offload (bool):
             Whether to offload parameters to CPU. Defaults to `True`.
-        is_transformer (bool):
-            Whether the model is a transformer. Defaults to `False`.
-        layer_to_wrap (nn.Module, optional):
-            The specific layer to wrap for transformer models. Required if `is_transformer` is `True`.
 
     Returns:
         FullyShardedDataParallel:
@@ -96,34 +81,16 @@ def apply_fsdp(
             If the distributed initialization fails.
     """
     dist.init_process_group("nccl", rank=rank, world_size=world_size)
-    device = torch.device(f"cuda:{local_rank}")
     torch.cuda.set_device(local_rank)
 
-    if not hasattr(ShardingStrategy, sharding_strategy):
-        msg = f"The provided sharding strategy {sharding_strategy} does not exist."
-        raise ValueError(msg)
-    sharding_strategy = getattr(ShardingStrategy, sharding_strategy)
-    if is_transformer:
-        if layer_to_wrap is None:
-            raise ValueError("`layer_to_wrap` must be provided for transformer models.")
-        my_auto_wrap_policy = functools.partial(
-            transformer_auto_wrap_policy,
-            transformer_layer_cls={layer_to_wrap},
-        )
+    if cpu_offload:
+        offload_policy = OffloadPolicy()
     else:
-        my_auto_wrap_policy = functools.partial(
-            size_based_auto_wrap_policy,
-            min_num_params=100,
-        )
+        offload_policy = CPUOffloadPolicy()
 
-    fsdp_cfg = {
-        "use_orig_params": False,
-        "sharding_strategy": sharding_strategy,
-        "auto_wrap_policy": my_auto_wrap_policy,
-        "cpu_offload": CPUOffload(offload_params=cpu_offload),
-    }
-
-    model = model.to(device=device)
-    model = FSDP(model, **fsdp_cfg)
+    model = fully_shard(
+        model,
+        offload_policy=offload_policy,
+    )
 
     return model

--- a/kronfluence/utils/model.py
+++ b/kronfluence/utils/model.py
@@ -7,6 +7,8 @@ from torch import nn
 from torch.distributed.fsdp import fully_shard, OffloadPolicy, CPUOffloadPolicy, FSDPModule
 from torch.nn.parallel.distributed import DistributedDataParallel
 
+from kronfluence.utils.state import State
+
 
 def apply_ddp(
     model: nn.Module,
@@ -51,9 +53,7 @@ def apply_ddp(
 
 def apply_fsdp(
     model: nn.Module,
-    local_rank: int,
-    rank: int,
-    world_size: int,
+    sequential: nn.Sequential,
     cpu_offload: bool = True,
 ) -> FSDPModule:
     """Applies FSDP2 to the given PyTorch model.
@@ -61,12 +61,6 @@ def apply_fsdp(
     Args:
         model (nn.Module):
             The PyTorch model to be parallelized.
-        local_rank (int):
-            The local rank of the current process within its node.
-        rank (int):
-            The global rank of the current process across all nodes.
-        world_size (int):
-            The total number of processes in the distributed setup.
         cpu_offload (bool):
             Whether to offload parameters to CPU. Defaults to `True`.
 
@@ -80,17 +74,24 @@ def apply_fsdp(
         RuntimeError:
             If the distributed initialization fails.
     """
-    dist.init_process_group("nccl", rank=rank, world_size=world_size)
-    torch.cuda.set_device(local_rank)
+    state = State()
 
     if cpu_offload:
         offload_policy = OffloadPolicy()
     else:
         offload_policy = CPUOffloadPolicy()
 
+    for i in range(len(sequential)):
+        fully_shard(
+            sequential[i],
+            offload_policy=offload_policy,
+            mesh=state.mesh,
+        )
+
     model = fully_shard(
         model,
         offload_policy=offload_policy,
+        mesh=state.mesh,
     )
 
     return model

--- a/kronfluence/utils/model.py
+++ b/kronfluence/utils/model.py
@@ -53,7 +53,7 @@ def apply_ddp(
 
 def apply_fsdp(
     model: nn.Module,
-    sequential: nn.Sequential,
+    sequential: nn.Sequential | nn.ModuleList,
     cpu_offload: bool = True,
 ) -> FSDPModule:
     """Applies FSDP2 to the given PyTorch model.

--- a/kronfluence/utils/sharded_storage.py
+++ b/kronfluence/utils/sharded_storage.py
@@ -2,25 +2,22 @@
 
 from dataclasses import dataclass
 from enum import Enum
-from types import NoneType
 from torch import Tensor
-import torch
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.placement_types import Replicate, Shard, Partial
 from torch.distributed.tensor.device_mesh import DeviceMesh
 
+from torch.utils._pytree import PyTree, tree_map, tree_all
+
 from kronfluence.utils.state import State, release_memory
 
-class ReduceStratagy(Enum):
-    """Strategy for reducing a sharded buffer."""
-    NONE = "none"
-    ACCUMULATE = "accumulate"
 
 @dataclass(frozen=True, eq=True)
 class BufferConfig:
     """Configuration for a sharded buffer."""
     shard: bool = False
     shard_dim: int = 0
+
 
 class BufferState(Enum):
     """State of a sharded buffer."""
@@ -30,14 +27,18 @@ class BufferState(Enum):
     REPLICATED = "replicated"
     LOCAL = "local"
 
+
 class ShardedStorage:
     """Sharded storage for PyTorch tensors."""
 
     buffer_configs: dict[str, BufferConfig]
-    sharded_buffers: dict[str, DTensor]
-    unsharded_buffers: dict[str, Tensor | DTensor]
+    """Configuration for each buffer. Should only be set when a buffer is registered."""
+    sharded_buffers: dict[str, PyTree]
+    """Buffers that are currently sharded across the device mesh."""
+    unsharded_buffers: dict[str, PyTree]
+    """Buffers that are currently unsharded across the device mesh."""
     buffer_states: dict[str, BufferState]
-    materialized: bool = True
+    """State of each buffer."""
 
     def __init__(self, state: State | None = None, mesh: DeviceMesh | None = None):
         self.buffer_configs = {}
@@ -105,7 +106,7 @@ class ShardedStorage:
             release_memory()
             self.buffer_states[key] = BufferState.UNINITIALIZED
 
-    def __setitem__(self, key: str, value: Tensor | list[Tensor] | None):
+    def __setitem__(self, key: str, value: PyTree | None):
         if key not in self:
             raise KeyError(f"Buffer {key} is not registered.")
 
@@ -114,19 +115,15 @@ class ShardedStorage:
                     "We currently do not support setting a value to a sharded or replicated buffer. This is probably a mistake."
             )
 
-        if self.buffer_configs[key].shard and not isinstance(value, (NoneType, Tensor)):
-            raise ValueError("Sharded storage does not currently support setting a list of tensors.")
-
-
-
         # Delete buffer
-        assert not isinstance(value, DTensor), "Sharded storage only supports tensors."
         del self[key]
 
         # setting to None just deletes the buffer
         if value is None:
             return
 
+        assert tree_all(lambda x: isinstance(x, (Tensor,)), value), "Supports setting pytrees with tensors as leaves."
+    
         # Initialize buffer again
         self.unsharded_buffers[key] = value
 
@@ -134,30 +131,29 @@ class ShardedStorage:
             self.buffer_states[key] = BufferState.NEEDS_SHARDING
         else:
             self.buffer_states[key] = BufferState.LOCAL
-            self.unsharded_buffers[key] = self.unsharded_buffers[key].to(self.state.device)
+            self.unsharded_buffers[key] = tree_map(lambda x: x.to(self.state.device), self.unsharded_buffers[key])
 
-    def accumulate(self, key: str, value: Tensor) -> None:
-        assert isinstance(value, Tensor), "Sharded storage only supports tensors."
+    def accumulate(self, key: str, value: PyTree) -> None:
         if key not in self:
             raise KeyError(f"Buffer {key} is not registered.")
         
         match self.buffer_states[key]:
             case BufferState.LOCAL | BufferState.NEEDS_SHARDING:
-                self.unsharded_buffers[key].add_(value)
+                self.unsharded_buffers[key] = tree_map(lambda x, y: x.add_(y), self.unsharded_buffers[key], value)
             case BufferState.SHARDED:
                 sharded_tensor = self.sharded_buffers[key]
                 config = self.buffer_configs[key]
-                replicated_value = DTensor.from_local(
-                    value,
-                    device_mesh=sharded_tensor.device_mesh,
+                replicated_value = tree_map(lambda x: DTensor.from_local(
+                    x,
+                    device_mesh=self.mesh,
                     placements=[Partial(reduce_op='sum')],
-                )
-                sharded_value = replicated_value.redistribute(
+                ), value)
+                sharded_value = tree_map(lambda x: x.redistribute(
                     self.mesh,
                     placements=[Shard(config.shard_dim)],
-                )
-                sharded_tensor.add_(sharded_value)
-            
+                ), replicated_value)
+                self.sharded_buffers[key] = tree_map(lambda x, y: x.add_(y), sharded_tensor, sharded_value)
+
                 del replicated_value
                 del sharded_value
             case _:
@@ -180,12 +176,12 @@ class ShardedStorage:
                 return
             case BufferState.SHARDED:
                 sharded_tensor = self.sharded_buffers[key]
-                replicated_tensor = sharded_tensor.redistribute(
+                replicated_tensor = tree_map(lambda x: x.redistribute(
                     self.mesh,
                     placements=[Replicate()],
-                )
+                ), sharded_tensor)
                 self.buffer_states[key] = BufferState.REPLICATED
-                self.unsharded_buffers[key] = replicated_tensor.to_local()
+                self.unsharded_buffers[key] = tree_map(lambda x: x.to_local(), replicated_tensor)
             case _:
                 raise ValueError(f"Invalid buffer state: {self.buffer_states[key]}")
 
@@ -202,15 +198,16 @@ class ShardedStorage:
             case BufferState.NEEDS_SHARDING:
                 config = self.buffer_configs[key]
                 assert not isinstance(self.unsharded_buffers[key], DTensor), "Invariant violated!"
-                replicated_tensor = DTensor.from_local(
-                    self.unsharded_buffers[key],
+                replicated_tensor = tree_map(lambda x: DTensor.from_local(
+                    x,
                     device_mesh=self.mesh,
                     placements=[Replicate()],
-                )
-                sharded_tensor = replicated_tensor.redistribute(
+                ), self.unsharded_buffers[key])
+
+                sharded_tensor = tree_map(lambda x: x.redistribute(
                     self.mesh,
                     placements=[Shard(config.shard_dim)],
-                )
+                ), replicated_tensor)
                 del replicated_tensor
                 del self.unsharded_buffers[key]
                 self.state.wait_for_everyone()

--- a/kronfluence/utils/sharded_storage.py
+++ b/kronfluence/utils/sharded_storage.py
@@ -184,7 +184,7 @@ class ShardedStorage:
                     placements=[Replicate()],
                 )
                 self.buffer_states[key] = BufferState.REPLICATED
-                self.unsharded_buffers[key] = replicated_tensor
+                self.unsharded_buffers[key] = replicated_tensor.to_local()
             case _:
                 raise ValueError(f"Invalid buffer state: {self.buffer_states[key]}")
 

--- a/kronfluence/utils/sharded_storage.py
+++ b/kronfluence/utils/sharded_storage.py
@@ -9,7 +9,7 @@ from torch.distributed.tensor.device_mesh import DeviceMesh
 
 from torch.utils._pytree import PyTree, tree_map, tree_all
 
-from kronfluence.utils.state import State, release_memory
+from kronfluence.utils.state import State
 
 
 @dataclass(frozen=True, eq=True)
@@ -103,7 +103,6 @@ class ShardedStorage:
                 del self.sharded_buffers[key]
             if self.buffer_states[key] in [BufferState.SHARDED, BufferState.REPLICATED]:
                 self.state.wait_for_everyone()
-            release_memory()
             self.buffer_states[key] = BufferState.UNINITIALIZED
 
     def __setitem__(self, key: str, value: PyTree | None):
@@ -193,7 +192,6 @@ class ShardedStorage:
             case BufferState.REPLICATED:
                 del self.unsharded_buffers[key]
                 self.state.wait_for_everyone()
-                release_memory()
                 self.buffer_states[key] = BufferState.SHARDED
             case BufferState.NEEDS_SHARDING:
                 config = self.buffer_configs[key]
@@ -211,7 +209,6 @@ class ShardedStorage:
                 del replicated_tensor
                 del self.unsharded_buffers[key]
                 self.state.wait_for_everyone()
-                release_memory()
                 self.buffer_states[key] = BufferState.SHARDED
                 self.sharded_buffers[key] = sharded_tensor
 

--- a/kronfluence/utils/sharded_storage.py
+++ b/kronfluence/utils/sharded_storage.py
@@ -1,0 +1,168 @@
+"""Implementation of sharded storage inspired by FSDP."""
+
+from dataclasses import dataclass
+from enum import Enum
+from torch import Tensor
+from torch.distributed.tensor import DTensor
+from torch.distributed.tensor.placement_types import Replicate, Shard, Partial
+from torch.distributed.tensor.device_mesh import DeviceMesh
+from torch.futures import Future
+
+from kronfluence.utils.state import State, release_memory
+
+
+class ReduceStratagy(Enum):
+    """Strategy for reducing a sharded buffer."""
+    NONE = "none"
+    ACCUMULATE = "accumulate"
+
+
+@dataclass
+class BufferConfig:
+    """Configuration for a sharded buffer."""
+    shard: bool = False
+    materialize_on_forward: bool = False
+    materialize_on_backward: bool = False
+    shard_dim: int = 0
+
+
+class BufferState(Enum):
+    """State of a sharded buffer."""
+    UNINITIALIZED = "uninitialized"
+    NEEDS_SHARDING = "initialized_needs_sharding"
+    SHARDED = "sharded"
+    REPLICATED = "replicated"
+    LOCAL = "local"
+
+class ShardedStorage:
+    """Sharded storage for PyTorch tensors."""
+
+    buffer_configs: dict[str, BufferConfig]
+    sharded_buffers: dict[str, DTensor]
+    unsharded_buffers: dict[str, Tensor | DTensor]
+    buffer_states: dict[str, BufferState]
+
+    def __init__(self, state: State):
+        self.buffer_configs = {}
+        self.sharded_buffers = {}
+        self.unsharded_buffers = {}
+        self.buffer_states = {}
+        self.state = state if state is not None else State()
+        self.mesh = DeviceMesh() # TODO initialize mesh
+
+    def register_buffer(self, name: str, config: BufferConfig):
+        self.buffer_configs[name] = config
+        self.buffer_states[name] = BufferState.UNINITIALIZED
+
+    def is_initialized(self, key: str) -> bool:
+        return self.buffer_states[key] != BufferState.UNINITIALIZED
+
+    def __contains__(self, key: str) -> bool:
+        # Assert key in config iff key in states
+        assert key in self.buffer_configs == key in self.buffer_states, "Invariant violated!"
+        return key in self.buffer_configs
+
+    def __getitem__(self, key: str) -> Tensor | DTensor | None:
+        if key not in self:
+            raise KeyError(f"Buffer {key} is not registered.")
+        
+        match self.buffer_states[key]:
+            case BufferState.SHARDED:
+                raise ValueError(
+                    f"Buffer {key} is sharded with placements {self.unsharded_buffers[key].placements}."
+                    "Please ensure this buffer is materialized on the local process."
+                )
+            case BufferState.LOCAL | BufferState.NEEDS_SHARDING:
+                assert not isinstance(self.unsharded_buffers[key], DTensor), "Invariant violated!"
+                return self.unsharded_buffers[key]
+            case BufferState.UNINITIALIZED:
+                return None
+            case BufferState.REPLICATED:
+                return self.unsharded_buffers[key]
+            case _:
+                raise ValueError(f"Invalid buffer state: {self.buffer_states[key]}")
+
+    def __delitem__(self, key: str):
+        if key not in self:
+            raise KeyError(f"Buffer {key} is not registered.")
+
+        if self.buffer_states[key] != BufferState.UNINITIALIZED:
+            del self.unsharded_buffers[key]
+            if key in self.sharded_buffers:
+                del self.sharded_buffers[key]
+            if self.buffer_states[key] in [BufferState.SHARDED, BufferState.REPLICATED]:
+                self.state.wait_for_everyone()
+            release_memory()
+            self.buffer_states[key] = BufferState.UNINITIALIZED
+
+    def __setitem__(self, key: str, value: Tensor | None):
+        if key not in self:
+            raise KeyError(f"Buffer {key} is not registered.")
+
+        # Delete buffer
+        assert not isinstance(value, DTensor), "Sharded storage only supports tensors."
+        del self[key]
+
+        # setting to None just deletes the buffer
+        if value is None:
+            return
+
+        # Initialize buffer again
+        self.unsharded_buffers[key] = value
+
+        if self.buffer_configs[key].shard:
+            self.buffer_states[key] = BufferState.NEEDS_SHARDING
+        else:
+            self.buffer_states[key] = BufferState.LOCAL
+
+
+    def _materialize(self, key: str) -> None:
+        if key not in self:
+            raise KeyError(f"Buffer {key} is not registered.")
+
+        match self.buffer_states[key]:
+            case (
+                    BufferState.REPLICATED 
+                    | BufferState.LOCAL 
+                    | BufferState.UNINITIALIZED 
+                    | BufferState.NEEDS_SHARDING
+                ):
+                return
+            case BufferState.SHARDED:
+                sharded_tensor = self.sharded_buffers[key]
+                replicated_tensor = sharded_tensor.redistribute(
+                    self.mesh,
+                    placements=[Replicate()],
+                )
+                self.buffer_states[key] = BufferState.REPLICATED
+                self.unsharded_buffers[key] = replicated_tensor
+            case _:
+                raise ValueError(f"Invalid buffer state: {self.buffer_states[key]}")
+
+
+    def _dematerialize(self, key: str) -> None:
+        match self.buffer_states[key]:
+            case BufferState.UNINITIALIZED | BufferState.LOCAL | BufferState.SHARDED:
+                return
+            case BufferState.REPLICATED:
+                del self.unsharded_buffers[key]
+                self.state.wait_for_everyone()
+                release_memory()
+                self.buffer_states[key] = BufferState.SHARDED
+            case BufferState.NEEDS_SHARDING:
+                config = self.buffer_configs[key]
+                assert not isinstance(self.unsharded_buffers[key], DTensor), "Invariant violated!"
+                sharded_tensor = DTensor.from_local(
+                    self.unsharded_buffers[key],
+                    placements=[Shard(config.shard_dim)],
+                )
+                self.buffer_states[key] = BufferState.SHARDED
+                self.sharded_buffers[key] = sharded_tensor
+
+    def materialize_all(self) -> None:
+        for key in self.buffer_configs:
+            self._materialize(key)
+
+    def dematerialize_all(self) -> None:
+        for key in self.buffer_configs:
+            self._dematerialize(key)

--- a/kronfluence/utils/sharded_storage.py
+++ b/kronfluence/utils/sharded_storage.py
@@ -6,7 +6,7 @@ from types import NoneType
 from torch import Tensor
 import torch
 from torch.distributed.tensor import DTensor
-from torch.distributed.tensor.placement_types import Replicate, Shard
+from torch.distributed.tensor.placement_types import Replicate, Shard, Partial
 from torch.distributed.tensor.device_mesh import DeviceMesh
 
 from kronfluence.utils.state import State, release_memory
@@ -16,7 +16,7 @@ class ReduceStratagy(Enum):
     NONE = "none"
     ACCUMULATE = "accumulate"
 
-@dataclass
+@dataclass(frozen=True, eq=True)
 class BufferConfig:
     """Configuration for a sharded buffer."""
     shard: bool = False
@@ -37,6 +37,7 @@ class ShardedStorage:
     sharded_buffers: dict[str, DTensor]
     unsharded_buffers: dict[str, Tensor | DTensor]
     buffer_states: dict[str, BufferState]
+    materialized: bool = True
 
     def __init__(self, state: State | None = None, mesh: DeviceMesh | None = None):
         self.buffer_configs = {}
@@ -46,11 +47,17 @@ class ShardedStorage:
         self.state = State() if state is None else state
         # Try to initialize mesh from state
         if mesh is None:
-            self.mesh = self.state.mesh
+            mesh = self.state.mesh
 
         self.mesh = mesh
 
     def register_buffer(self, name: str, config: BufferConfig):
+        if name in self.buffer_configs and config == self.buffer_configs[name]:
+            return
+
+        if name in self.buffer_configs and self.buffer_states[name] != BufferState.UNINITIALIZED:
+            raise ValueError(f"Cannot update buffer config for {name} while it is initialized.")
+
         self.buffer_configs[name] = config
         self.buffer_states[name] = BufferState.UNINITIALIZED
 
@@ -72,7 +79,7 @@ class ShardedStorage:
             case BufferState.SHARDED:
                 raise ValueError(
                     f"Buffer {key} is sharded with placements {self.sharded_buffers[key].placements}."
-                    "Please ensure this buffer is materialized on the local process."
+                    "Please ensure this buffer is fully materialized on the local process."
                 )
             case BufferState.LOCAL | BufferState.NEEDS_SHARDING:
                 assert not isinstance(self.unsharded_buffers[key], DTensor), "Invariant violated!"
@@ -102,9 +109,15 @@ class ShardedStorage:
         if key not in self:
             raise KeyError(f"Buffer {key} is not registered.")
 
+        if self.buffer_states[key] in [BufferState.SHARDED, BufferState.REPLICATED] and value is not None:
+            raise AssertionError(
+                    "We currently do not support setting a value to a sharded or replicated buffer. This is probably a mistake."
+            )
 
         if self.buffer_configs[key].shard and not isinstance(value, (NoneType, Tensor)):
             raise ValueError("Sharded storage does not currently support setting a list of tensors.")
+
+
 
         # Delete buffer
         assert not isinstance(value, DTensor), "Sharded storage only supports tensors."
@@ -122,33 +135,45 @@ class ShardedStorage:
         else:
             self.buffer_states[key] = BufferState.LOCAL
 
-    def accumulate(self, key: str, tensor: Tensor) -> None:
+    def accumulate(self, key: str, value: Tensor) -> None:
+        assert isinstance(value, Tensor), "Sharded storage only supports tensors."
         if key not in self:
             raise KeyError(f"Buffer {key} is not registered.")
         
         match self.buffer_states[key]:
             case BufferState.LOCAL | BufferState.NEEDS_SHARDING:
-                self.unsharded_buffers[key] += tensor
+                self.unsharded_buffers[key].add_(value)
             case BufferState.SHARDED:
                 sharded_tensor = self.sharded_buffers[key]
-                dtensor = DTensor.from_local(
-                    tensor,
+                config = self.buffer_configs[key]
+                replicated_value = DTensor.from_local(
+                    value,
                     device_mesh=sharded_tensor.device_mesh,
-                    placements=sharded_tensor.placements,
+                    placements=[Partial(reduce_op='sum')],
                 )
-                sharded_tensor += dtensor
+                sharded_value = replicated_value.redistribute(
+                    self.mesh,
+                    placements=[Shard(config.shard_dim)],
+                )
+                sharded_tensor.add_(sharded_value)
+            
+                del replicated_value
+                del sharded_value
             case _:
                 raise ValueError(f"Invalid buffer state for modification: {self.buffer_states[key]}")
 
-    def _materialize(self, key: str) -> None:
+    def is_materialized(self, key: str) -> bool:
+        return self.buffer_states[key] != BufferState.SHARDED
+
+    def materialize_buffer(self, key: str) -> None:
         if key not in self:
             raise KeyError(f"Buffer {key} is not registered.")
 
         match self.buffer_states[key]:
             case (
-                    BufferState.REPLICATED 
-                    | BufferState.LOCAL 
-                    | BufferState.UNINITIALIZED 
+                    BufferState.REPLICATED
+                    | BufferState.LOCAL
+                    | BufferState.UNINITIALIZED
                     | BufferState.NEEDS_SHARDING
                 ):
                 return
@@ -164,7 +189,7 @@ class ShardedStorage:
                 raise ValueError(f"Invalid buffer state: {self.buffer_states[key]}")
 
 
-    def _dematerialize(self, key: str) -> None:
+    def dematerialize_buffer(self, key: str) -> None:
         match self.buffer_states[key]:
             case BufferState.UNINITIALIZED | BufferState.LOCAL | BufferState.SHARDED:
                 return
@@ -176,11 +201,16 @@ class ShardedStorage:
             case BufferState.NEEDS_SHARDING:
                 config = self.buffer_configs[key]
                 assert not isinstance(self.unsharded_buffers[key], DTensor), "Invariant violated!"
-                sharded_tensor = DTensor.from_local(
+                replicated_tensor = DTensor.from_local(
                     self.unsharded_buffers[key],
                     device_mesh=self.mesh,
+                    placements=[Replicate()],
+                )
+                sharded_tensor = replicated_tensor.redistribute(
+                    self.mesh,
                     placements=[Shard(config.shard_dim)],
                 )
+                del replicated_tensor
                 del self.unsharded_buffers[key]
                 self.state.wait_for_everyone()
                 release_memory()
@@ -189,8 +219,8 @@ class ShardedStorage:
 
     def materialize_all(self) -> None:
         for key in self.buffer_configs:
-            self._materialize(key)
+            self.materialize_buffer(key)
 
     def dematerialize_all(self) -> None:
         for key in self.buffer_configs:
-            self._dematerialize(key)
+            self.dematerialize_buffer(key)

--- a/kronfluence/utils/sharded_storage.py
+++ b/kronfluence/utils/sharded_storage.py
@@ -74,7 +74,7 @@ class ShardedStorage:
     def __getitem__(self, key: str) -> list[Tensor] | Tensor | DTensor | None:
         if key not in self:
             raise KeyError(f"Buffer {key} is not registered.")
-        
+
         match self.buffer_states[key]:
             case BufferState.SHARDED:
                 raise ValueError(

--- a/kronfluence/utils/sharded_storage.py
+++ b/kronfluence/utils/sharded_storage.py
@@ -134,6 +134,7 @@ class ShardedStorage:
             self.buffer_states[key] = BufferState.NEEDS_SHARDING
         else:
             self.buffer_states[key] = BufferState.LOCAL
+            self.unsharded_buffers[key] = self.unsharded_buffers[key].to(self.state.device)
 
     def accumulate(self, key: str, value: Tensor) -> None:
         assert isinstance(value, Tensor), "Sharded storage only supports tensors."

--- a/kronfluence/utils/sharded_storage.py
+++ b/kronfluence/utils/sharded_storage.py
@@ -2,29 +2,25 @@
 
 from dataclasses import dataclass
 from enum import Enum
+from types import NoneType
 from torch import Tensor
+import torch
 from torch.distributed.tensor import DTensor
-from torch.distributed.tensor.placement_types import Replicate, Shard, Partial
+from torch.distributed.tensor.placement_types import Replicate, Shard
 from torch.distributed.tensor.device_mesh import DeviceMesh
-from torch.futures import Future
 
 from kronfluence.utils.state import State, release_memory
-
 
 class ReduceStratagy(Enum):
     """Strategy for reducing a sharded buffer."""
     NONE = "none"
     ACCUMULATE = "accumulate"
 
-
 @dataclass
 class BufferConfig:
     """Configuration for a sharded buffer."""
     shard: bool = False
-    materialize_on_forward: bool = False
-    materialize_on_backward: bool = False
     shard_dim: int = 0
-
 
 class BufferState(Enum):
     """State of a sharded buffer."""
@@ -42,13 +38,17 @@ class ShardedStorage:
     unsharded_buffers: dict[str, Tensor | DTensor]
     buffer_states: dict[str, BufferState]
 
-    def __init__(self, state: State):
+    def __init__(self, state: State | None = None, mesh: DeviceMesh | None = None):
         self.buffer_configs = {}
         self.sharded_buffers = {}
         self.unsharded_buffers = {}
         self.buffer_states = {}
-        self.state = state if state is not None else State()
-        self.mesh = DeviceMesh() # TODO initialize mesh
+        self.state = State() if state is None else state
+        # Try to initialize mesh from state
+        if mesh is None:
+            self.mesh = self.state.mesh
+
+        self.mesh = mesh
 
     def register_buffer(self, name: str, config: BufferConfig):
         self.buffer_configs[name] = config
@@ -59,17 +59,19 @@ class ShardedStorage:
 
     def __contains__(self, key: str) -> bool:
         # Assert key in config iff key in states
-        assert key in self.buffer_configs == key in self.buffer_states, "Invariant violated!"
+        assert (key in self.buffer_configs) == (
+            key in self.buffer_states
+        ), "Invariant violated!"
         return key in self.buffer_configs
 
-    def __getitem__(self, key: str) -> Tensor | DTensor | None:
+    def __getitem__(self, key: str) -> list[Tensor] | Tensor | DTensor | None:
         if key not in self:
             raise KeyError(f"Buffer {key} is not registered.")
         
         match self.buffer_states[key]:
             case BufferState.SHARDED:
                 raise ValueError(
-                    f"Buffer {key} is sharded with placements {self.unsharded_buffers[key].placements}."
+                    f"Buffer {key} is sharded with placements {self.sharded_buffers[key].placements}."
                     "Please ensure this buffer is materialized on the local process."
                 )
             case BufferState.LOCAL | BufferState.NEEDS_SHARDING:
@@ -87,7 +89,8 @@ class ShardedStorage:
             raise KeyError(f"Buffer {key} is not registered.")
 
         if self.buffer_states[key] != BufferState.UNINITIALIZED:
-            del self.unsharded_buffers[key]
+            if key in self.unsharded_buffers:
+                del self.unsharded_buffers[key]
             if key in self.sharded_buffers:
                 del self.sharded_buffers[key]
             if self.buffer_states[key] in [BufferState.SHARDED, BufferState.REPLICATED]:
@@ -95,9 +98,13 @@ class ShardedStorage:
             release_memory()
             self.buffer_states[key] = BufferState.UNINITIALIZED
 
-    def __setitem__(self, key: str, value: Tensor | None):
+    def __setitem__(self, key: str, value: Tensor | list[Tensor] | None):
         if key not in self:
             raise KeyError(f"Buffer {key} is not registered.")
+
+
+        if self.buffer_configs[key].shard and not isinstance(value, (NoneType, Tensor)):
+            raise ValueError("Sharded storage does not currently support setting a list of tensors.")
 
         # Delete buffer
         assert not isinstance(value, DTensor), "Sharded storage only supports tensors."
@@ -115,6 +122,23 @@ class ShardedStorage:
         else:
             self.buffer_states[key] = BufferState.LOCAL
 
+    def accumulate(self, key: str, tensor: Tensor) -> None:
+        if key not in self:
+            raise KeyError(f"Buffer {key} is not registered.")
+        
+        match self.buffer_states[key]:
+            case BufferState.LOCAL | BufferState.NEEDS_SHARDING:
+                self.unsharded_buffers[key] += tensor
+            case BufferState.SHARDED:
+                sharded_tensor = self.sharded_buffers[key]
+                dtensor = DTensor.from_local(
+                    tensor,
+                    device_mesh=sharded_tensor.device_mesh,
+                    placements=sharded_tensor.placements,
+                )
+                sharded_tensor += dtensor
+            case _:
+                raise ValueError(f"Invalid buffer state for modification: {self.buffer_states[key]}")
 
     def _materialize(self, key: str) -> None:
         if key not in self:
@@ -154,8 +178,12 @@ class ShardedStorage:
                 assert not isinstance(self.unsharded_buffers[key], DTensor), "Invariant violated!"
                 sharded_tensor = DTensor.from_local(
                     self.unsharded_buffers[key],
+                    device_mesh=self.mesh,
                     placements=[Shard(config.shard_dim)],
                 )
+                del self.unsharded_buffers[key]
+                self.state.wait_for_everyone()
+                release_memory()
                 self.buffer_states[key] = BufferState.SHARDED
                 self.sharded_buffers[key] = sharded_tensor
 

--- a/kronfluence/utils/state.py
+++ b/kronfluence/utils/state.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, List
 import torch
 import torch.distributed as dist
 from accelerate.state import SharedDict
+from torch.distributed.tensor.device_mesh import init_device_mesh
 from torch import nn
 
 
@@ -34,19 +35,23 @@ class State:
             self.cpu = cpu
 
             if int(os.environ.get("LOCAL_RANK", -1)) != -1 and not cpu and torch.cuda.is_available():
-                if not dist.is_initialized():
-                    dist.init_process_group(backend="nccl")
-                self.num_processes = dist.get_world_size()
-                self.process_index = dist.get_rank()
+                if not dist.distributed_c10d.is_initialized():
+                    dist.distributed_c10d.init_process_group('nccl')
+                self.num_processes = dist.distributed_c10d.get_world_size()
+                self.process_index = dist.distributed_c10d.get_rank()
                 self.local_process_index = int(os.environ.get("LOCAL_RANK", -1))
                 self.device = torch.device("cuda", self.local_process_index)
                 self.n_gpus = torch.cuda.device_count()
+                # Get the default process group
+                self.process_group = dist.distributed_c10d._get_default_group()
                 torch.cuda.set_device(self.device)
+                self.mesh = init_device_mesh(self.device.type, mesh_shape=(self.num_processes,), mesh_dim_names=("dp",))
             else:
                 self.num_processes = 1
                 self.process_index = self.local_process_index = 0
                 self.n_gpus = torch.cuda.device_count()
                 self.device = torch.device("cpu") if self.cpu else self.default_device
+                self.mesh = None
 
     def __repr__(self) -> str:
         """Provides a string representation of the `State` instance.

--- a/kronfluence/version.py
+++ b/kronfluence/version.py
@@ -1,1 +1,1 @@
-__version__ = "1.1.0.beta3"
+__version__ = "1.1.0.beta4"

--- a/kronfluence/version.py
+++ b/kronfluence/version.py
@@ -1,1 +1,1 @@
-__version__ = "1.1.0.beta4"
+__version__ = "1.1.0.beta5"

--- a/kronfluence/version.py
+++ b/kronfluence/version.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.1"
+__version__ = "1.1.0.beta1"

--- a/kronfluence/version.py
+++ b/kronfluence/version.py
@@ -1,1 +1,1 @@
-__version__ = "1.1.0.beta2"
+__version__ = "1.1.0.beta3"

--- a/kronfluence/version.py
+++ b/kronfluence/version.py
@@ -1,1 +1,1 @@
-__version__ = "1.1.0.beta1"
+__version__ = "1.1.0.beta2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch>=2.1.0
+torch>=2.7.0
 torchvision>=0.16.0
 accelerate>=0.31.0
 einops>=0.8.0

--- a/tests/gpu_tests/fsdp_test.py
+++ b/tests/gpu_tests/fsdp_test.py
@@ -45,7 +45,7 @@ class FSDPTest(unittest.TestCase):
 
         cls.task = GpuTestTask()
         cls.model = prepare_model(cls.model, cls.task)
-
+        cls.model.register_buffer("banana", torch.zeros(10, requires_grad=False))
         cls.model = apply_fsdp(
             model=cls.model,
             local_rank=LOCAL_RANK,
@@ -177,4 +177,6 @@ class FSDPTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    # Set working directory to be the folder containing this file
+    os.chdir(os.path.dirname(os.path.abspath(__file__)))
     unittest.main()

--- a/tests/gpu_tests/fsdp_test.py
+++ b/tests/gpu_tests/fsdp_test.py
@@ -8,7 +8,7 @@ import torch
 import torch.distributed as dist
 from torch.utils import data
 
-from kronfluence.analyzer import Analyzer, prepare_model
+from kronfluence.analyzer import Analyzer
 from kronfluence.utils.common.factor_arguments import pytest_factor_arguments
 from kronfluence.utils.common.score_arguments import pytest_score_arguments
 from kronfluence.utils.constants import (
@@ -16,6 +16,7 @@ from kronfluence.utils.constants import (
     COVARIANCE_FACTOR_NAMES,
     LAMBDA_FACTOR_NAMES,
 )
+from kronfluence.module.utils import wrap_tracked_modules
 from kronfluence.utils.model import apply_fsdp
 from tests.gpu_tests.pipeline import GpuTestTask, construct_test_mlp, get_mnist_dataset
 from tests.gpu_tests.prepare_tests import QUERY_INDICES, TRAIN_INDICES
@@ -24,7 +25,7 @@ from tests.utils import ATOL, RTOL, check_tensor_dict_equivalence
 LOCAL_RANK = int(os.environ["LOCAL_RANK"])
 WORLD_RANK = int(os.environ["RANK"])
 WORLD_SIZE = int(os.environ["WORLD_SIZE"])
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 OLD_FACTOR_NAME = "single_gpu"
 NEW_FACTOR_NAME = "fsdp"
 OLD_SCORE_NAME = "single_gpu"
@@ -43,8 +44,14 @@ class FSDPTest(unittest.TestCase):
         cls.eval_dataset = get_mnist_dataset(split="valid", data_path="data")
         cls.eval_dataset = data.Subset(cls.eval_dataset, indices=list(range(QUERY_INDICES)))
 
+        cls.factor_args = pytest_factor_arguments()
+        cls.factor_args.shard_covariance = True
+        cls.factor_args.shard_eigendecomposition = True
+        cls.factor_args.shard_lambda = True
+
         cls.task = GpuTestTask()
-        cls.model = prepare_model(cls.model, cls.task)
+        
+        cls.model = wrap_tracked_modules(cls.model, cls.task)
         cls.model = apply_fsdp(
             model=cls.model,
             sequential=cls.model,
@@ -60,11 +67,10 @@ class FSDPTest(unittest.TestCase):
 
     def test_covariance_matrices(self) -> None:
         covariance_factors = self.analyzer.load_covariance_matrices(factors_name=OLD_FACTOR_NAME)
-        factor_args = pytest_factor_arguments()
         self.analyzer.fit_covariance_matrices(
             factors_name=NEW_FACTOR_NAME,
             dataset=self.train_dataset,
-            factor_args=factor_args,
+            factor_args=self.factor_args,
             per_device_batch_size=512,
             overwrite_output_dir=True,
         )
@@ -86,11 +92,10 @@ class FSDPTest(unittest.TestCase):
 
     def test_lambda_matrices(self) -> None:
         lambda_factors = self.analyzer.load_lambda_matrices(factors_name=OLD_FACTOR_NAME)
-        factor_args = pytest_factor_arguments()
         self.analyzer.fit_lambda_matrices(
             factors_name=NEW_FACTOR_NAME,
             dataset=self.train_dataset,
-            factor_args=factor_args,
+            factor_args=self.factor_args,
             per_device_batch_size=512,
             overwrite_output_dir=True,
             load_from_factors_name=OLD_FACTOR_NAME,

--- a/tests/gpu_tests/fsdp_test.py
+++ b/tests/gpu_tests/fsdp_test.py
@@ -45,12 +45,9 @@ class FSDPTest(unittest.TestCase):
 
         cls.task = GpuTestTask()
         cls.model = prepare_model(cls.model, cls.task)
-        cls.model.register_buffer("banana", torch.zeros(10, requires_grad=False))
         cls.model = apply_fsdp(
             model=cls.model,
-            local_rank=LOCAL_RANK,
-            rank=WORLD_RANK,
-            world_size=WORLD_SIZE,
+            sequential=cls.model,
         )
         if LOCAL_RANK == 0:
             print(cls.model)

--- a/tests/gpu_tests/fsdp_test.py
+++ b/tests/gpu_tests/fsdp_test.py
@@ -122,7 +122,7 @@ class FSDPTest(unittest.TestCase):
         score_args = pytest_score_arguments()
         self.analyzer.compute_pairwise_scores(
             scores_name=NEW_SCORE_NAME,
-            factors_name=OLD_FACTOR_NAME,
+            factors_name=NEW_FACTOR_NAME,
             query_dataset=self.eval_dataset,
             train_dataset=self.train_dataset,
             train_indices=list(range(TRAIN_INDICES)),
@@ -152,7 +152,7 @@ class FSDPTest(unittest.TestCase):
         score_args = pytest_score_arguments()
         self.analyzer.compute_self_scores(
             scores_name=NEW_SCORE_NAME,
-            factors_name=OLD_FACTOR_NAME,
+            factors_name=NEW_FACTOR_NAME,
             train_dataset=self.train_dataset,
             train_indices=list(range(TRAIN_INDICES)),
             per_device_train_batch_size=512,

--- a/tests/utils/test_sharded_storage.py
+++ b/tests/utils/test_sharded_storage.py
@@ -87,15 +87,18 @@ def test_delete_buffer(sharded_storage):
 @patch("torch.distributed.tensor.DTensor.from_local")
 def test_sharded_buffer_lifecycle(mock_from_local, mock_release_memory, sharded_storage, mock_state):
     """Tests the full state transition lifecycle of a sharded buffer."""
-    mock_dtensor_instance = MagicMock()
-    mock_from_local.return_value = mock_dtensor_instance
+    mock_replicated_tensor = MagicMock()
+    mock_from_local.return_value = mock_replicated_tensor
 
-    mock_replicated_tensor = torch.randn(20)
+    mock_sharded_tensor = MagicMock()
+    def redistribute_effect_replicated(mesh, placements):
+        return mock_sharded_tensor
 
-    def redistribute_effect(mesh, placements):
+    def redistribute_effect_sharded(mesh, placements):
         return mock_replicated_tensor
 
-    mock_dtensor_instance.redistribute.side_effect = redistribute_effect
+    mock_replicated_tensor.redistribute.side_effect = redistribute_effect_replicated
+    mock_sharded_tensor.redistribute.side_effect = redistribute_effect_sharded
 
     config = BufferConfig(shard=True, shard_dim=0)
     sharded_storage.register_buffer("sharded_buffer", config)
@@ -107,30 +110,32 @@ def test_sharded_buffer_lifecycle(mock_from_local, mock_release_memory, sharded_
     assert torch.equal(sharded_storage["sharded_buffer"], tensor)
 
     # 2. Dematerialize -> SHARDED
-    sharded_storage._dematerialize("sharded_buffer")
+    sharded_storage.dematerialize_buffer("sharded_buffer")
     assert sharded_storage.buffer_states["sharded_buffer"] == BufferState.SHARDED
     mock_from_local.assert_called_once_with(
-        tensor, device_mesh=sharded_storage.mesh, placements=[Shard(config.shard_dim)]
+        tensor, device_mesh=sharded_storage.mesh, placements=[Replicate()]
     )
-    assert sharded_storage.sharded_buffers["sharded_buffer"] is mock_dtensor_instance
+    mock_replicated_tensor.redistribute.assert_called_once_with(
+        sharded_storage.mesh, placements=[Shard(config.shard_dim)]
+    )
+    assert sharded_storage.sharded_buffers["sharded_buffer"] is mock_sharded_tensor
     mock_state.wait_for_everyone.assert_called_once()
     mock_release_memory.assert_called_once()
     with pytest.raises(ValueError):
         _ = sharded_storage["sharded_buffer"]
 
     # 3. Materialize -> REPLICATED
-    sharded_storage._materialize("sharded_buffer")
+    sharded_storage.materialize_buffer("sharded_buffer")
     assert sharded_storage.buffer_states["sharded_buffer"] == BufferState.REPLICATED
-    mock_dtensor_instance.redistribute.assert_called_once_with(
+    mock_sharded_tensor.redistribute.assert_called_once_with(
         sharded_storage.mesh, placements=[Replicate()]
     )
-    assert torch.equal(sharded_storage["sharded_buffer"], mock_replicated_tensor)
     assert "sharded_buffer" in sharded_storage.unsharded_buffers
 
     # 4. Dematerialize again -> SHARDED
     mock_state.wait_for_everyone.reset_mock()
     mock_release_memory.reset_mock()
-    sharded_storage._dematerialize("sharded_buffer")
+    sharded_storage.dematerialize_buffer("sharded_buffer")
     assert sharded_storage.buffer_states["sharded_buffer"] == BufferState.SHARDED
     assert "sharded_buffer" not in sharded_storage.unsharded_buffers
     mock_state.wait_for_everyone.assert_called_once()
@@ -143,21 +148,21 @@ def test_sharded_buffer_lifecycle(mock_from_local, mock_release_memory, sharded_
 
 def test_materialize_all(sharded_storage):
     """Tests that materialize_all calls _materialize for each buffer."""
-    sharded_storage._materialize = MagicMock()
+    sharded_storage.materialize_buffer = MagicMock()
     sharded_storage.register_buffer("buf1", BufferConfig())
     sharded_storage.register_buffer("buf2", BufferConfig())
     sharded_storage.materialize_all()
-    assert sharded_storage._materialize.call_count == 2
-    sharded_storage._materialize.assert_any_call("buf1")
-    sharded_storage._materialize.assert_any_call("buf2")
+    assert sharded_storage.materialize_buffer.call_count == 2
+    sharded_storage.materialize_buffer.assert_any_call("buf1")
+    sharded_storage.materialize_buffer.assert_any_call("buf2")
 
 
 def test_dematerialize_all(sharded_storage):
     """Tests that dematerialize_all calls _dematerialize for each buffer."""
-    sharded_storage._dematerialize = MagicMock()
+    sharded_storage.dematerialize_buffer = MagicMock()
     sharded_storage.register_buffer("buf1", BufferConfig())
     sharded_storage.register_buffer("buf2", BufferConfig())
     sharded_storage.dematerialize_all()
-    assert sharded_storage._dematerialize.call_count == 2
-    sharded_storage._dematerialize.assert_any_call("buf1")
-    sharded_storage._dematerialize.assert_any_call("buf2") 
+    assert sharded_storage.dematerialize_buffer.call_count == 2
+    sharded_storage.dematerialize_buffer.assert_any_call("buf1")
+    sharded_storage.dematerialize_buffer.assert_any_call("buf2") 

--- a/tests/utils/test_sharded_storage.py
+++ b/tests/utils/test_sharded_storage.py
@@ -8,7 +8,7 @@ from kronfluence.utils.sharded_storage import (
     BufferState,
 )
 from kronfluence.utils.state import State
-from torch.distributed.tensor.placement_types import Replicate, Shard
+from torch.distributed.tensor.placement_types import Replicate, Shard, Partial
 
 
 @pytest.fixture
@@ -59,6 +59,47 @@ def test_set_and_get_local_buffer(sharded_storage):
     assert sharded_storage["local_buffer"] is None
 
 
+def test_set_and_get_local_buffer_pytree(sharded_storage):
+    """Tests setting, getting, and deleting a non-sharded PyTree buffer."""
+    config = BufferConfig(shard=False)
+    sharded_storage.register_buffer("local_pytree", config)
+    
+    # Test with dict PyTree
+    pytree_dict = {
+        "tensor1": torch.randn(10),
+        "tensor2": torch.randn(5, 5),
+        "nested": {
+            "tensor3": torch.randn(3, 3)
+        }
+    }
+    sharded_storage["local_pytree"] = pytree_dict
+
+    assert sharded_storage.buffer_states["local_pytree"] == BufferState.LOCAL
+    assert sharded_storage.is_initialized("local_pytree")
+    
+    # Verify the structure is preserved
+    retrieved = sharded_storage["local_pytree"]
+    assert torch.equal(retrieved["tensor1"], pytree_dict["tensor1"])
+    assert torch.equal(retrieved["tensor2"], pytree_dict["tensor2"])
+    assert torch.equal(retrieved["nested"]["tensor3"], pytree_dict["nested"]["tensor3"])
+
+    # Test with list PyTree
+    sharded_storage.register_buffer("local_list", config)
+    pytree_list = [torch.randn(10), torch.randn(5, 5), torch.randn(3, 3)]
+    sharded_storage["local_list"] = pytree_list
+    
+    assert sharded_storage.buffer_states["local_list"] == BufferState.LOCAL
+    retrieved_list = sharded_storage["local_list"]
+    for i, tensor in enumerate(pytree_list):
+        assert torch.equal(retrieved_list[i], tensor)
+
+    # Test deletion
+    sharded_storage["local_pytree"] = None
+    assert sharded_storage.buffer_states["local_pytree"] == BufferState.UNINITIALIZED
+    assert not sharded_storage.is_initialized("local_pytree")
+    assert sharded_storage["local_pytree"] is None
+
+
 def test_set_sharded_buffer(sharded_storage):
     """Tests setting a sharded buffer, which should put it in the NEEDS_SHARDING state."""
     config = BufferConfig(shard=True)
@@ -68,6 +109,29 @@ def test_set_sharded_buffer(sharded_storage):
 
     assert sharded_storage.buffer_states["sharded_buffer"] == BufferState.NEEDS_SHARDING
     assert torch.equal(sharded_storage["sharded_buffer"], tensor)
+
+
+def test_set_sharded_buffer_pytree(sharded_storage):
+    """Tests that sharded PyTree buffers are now supported."""
+    config = BufferConfig(shard=True)
+    sharded_storage.register_buffer("sharded_pytree", config)
+    
+    # PyTree structures are now supported for sharded buffers
+    pytree = {
+        "tensor1": torch.randn(20, 10),
+        "tensor2": torch.randn(30, 15),
+        "nested": {
+            "tensor3": torch.randn(40, 20)
+        }
+    }
+    # This should work now
+    sharded_storage["sharded_pytree"] = pytree
+
+    assert sharded_storage.buffer_states["sharded_pytree"] == BufferState.NEEDS_SHARDING
+    retrieved = sharded_storage["sharded_pytree"]
+    assert torch.equal(retrieved["tensor1"], pytree["tensor1"])
+    assert torch.equal(retrieved["tensor2"], pytree["tensor2"])
+    assert torch.equal(retrieved["nested"]["tensor3"], pytree["nested"]["tensor3"])
 
 
 def test_delete_buffer(sharded_storage):
@@ -81,6 +145,19 @@ def test_delete_buffer(sharded_storage):
     del sharded_storage["buffer_to_delete"]
     assert not sharded_storage.is_initialized("buffer_to_delete")
     assert sharded_storage.buffer_states["buffer_to_delete"] == BufferState.UNINITIALIZED
+
+
+def test_delete_buffer_pytree(sharded_storage):
+    """Tests the deletion of a PyTree buffer."""
+    config = BufferConfig(shard=False)
+    sharded_storage.register_buffer("pytree_to_delete", config)
+    pytree = {"a": torch.randn(10), "b": [torch.randn(5), torch.randn(3)]}
+    sharded_storage["pytree_to_delete"] = pytree
+
+    assert sharded_storage.is_initialized("pytree_to_delete")
+    del sharded_storage["pytree_to_delete"]
+    assert not sharded_storage.is_initialized("pytree_to_delete")
+    assert sharded_storage.buffer_states["pytree_to_delete"] == BufferState.UNINITIALIZED
 
 
 @patch("kronfluence.utils.sharded_storage.release_memory")
@@ -146,6 +223,119 @@ def test_sharded_buffer_lifecycle(mock_from_local, mock_release_memory, sharded_
     assert not sharded_storage.is_initialized("sharded_buffer")
 
 
+@patch("kronfluence.utils.sharded_storage.release_memory")
+@patch("torch.distributed.tensor.DTensor.from_local")
+def test_sharded_pytree_lifecycle(mock_from_local, mock_release_memory, sharded_storage, mock_state):
+    """Tests the full state transition lifecycle of a sharded PyTree buffer."""
+    config = BufferConfig(shard=True, shard_dim=0)
+    sharded_storage.register_buffer("sharded_pytree", config)
+    
+    pytree = {
+        "tensor1": torch.randn(20, 10),
+        "tensor2": torch.randn(30, 15),
+        "nested": {
+            "tensor3": torch.randn(40, 20)
+        }
+    }
+
+    # Keep track of tensor IDs to mock appropriately
+    tensor_ids = {
+        "tensor1": id(pytree["tensor1"]),
+        "tensor2": id(pytree["tensor2"]),
+        "tensor3": id(pytree["nested"]["tensor3"])
+    }
+
+    # Create mock DTensors for each tensor
+    mock_dtensor1 = MagicMock()
+    mock_dtensor2 = MagicMock()
+    mock_dtensor3 = MagicMock()
+    
+    # Mock redistributed tensors
+    mock_sharded1 = MagicMock()
+    mock_sharded2 = MagicMock()
+    mock_sharded3 = MagicMock()
+    
+    # Mock local tensors after to_local
+    mock_local1 = MagicMock()
+    mock_local2 = MagicMock()
+    mock_local3 = MagicMock()
+
+    # Setup redistribution
+    mock_dtensor1.redistribute.return_value = mock_sharded1
+    mock_dtensor2.redistribute.return_value = mock_sharded2
+    mock_dtensor3.redistribute.return_value = mock_sharded3
+    
+    mock_sharded1.redistribute.return_value = mock_dtensor1
+    mock_sharded2.redistribute.return_value = mock_dtensor2
+    mock_sharded3.redistribute.return_value = mock_dtensor3
+    
+    mock_dtensor1.to_local.return_value = mock_local1
+    mock_dtensor2.to_local.return_value = mock_local2
+    mock_dtensor3.to_local.return_value = mock_local3
+
+    # Map tensor IDs to their mocks
+    tensor_to_mock = {}
+    
+    def from_local_side_effect(tensor, **kwargs):
+        tid = id(tensor)
+        if tid == tensor_ids["tensor1"]:
+            return mock_dtensor1
+        elif tid == tensor_ids["tensor2"]:
+            return mock_dtensor2
+        elif tid == tensor_ids["tensor3"]:
+            return mock_dtensor3
+        return MagicMock()
+
+    mock_from_local.side_effect = from_local_side_effect
+
+    # 1. Set PyTree -> NEEDS_SHARDING
+    sharded_storage["sharded_pytree"] = pytree
+    assert sharded_storage.buffer_states["sharded_pytree"] == BufferState.NEEDS_SHARDING
+
+    # 2. Dematerialize -> SHARDED
+    sharded_storage.dematerialize_buffer("sharded_pytree")
+    assert sharded_storage.buffer_states["sharded_pytree"] == BufferState.SHARDED
+    assert "sharded_pytree" in sharded_storage.sharded_buffers
+    
+    # Verify from_local was called for each tensor
+    assert mock_from_local.call_count == 3
+    
+    # Verify redistribute was called to shard each tensor
+    mock_dtensor1.redistribute.assert_called_with(
+        sharded_storage.mesh, placements=[Shard(config.shard_dim)]
+    )
+    mock_dtensor2.redistribute.assert_called_with(
+        sharded_storage.mesh, placements=[Shard(config.shard_dim)]
+    )
+    mock_dtensor3.redistribute.assert_called_with(
+        sharded_storage.mesh, placements=[Shard(config.shard_dim)]
+    )
+    
+    # For PyTrees, the error will be AttributeError since dict doesn't have .placements
+    with pytest.raises((ValueError, AttributeError)):
+        _ = sharded_storage["sharded_pytree"]
+
+    # 3. Materialize -> REPLICATED
+    sharded_storage.materialize_buffer("sharded_pytree")
+    assert sharded_storage.buffer_states["sharded_pytree"] == BufferState.REPLICATED
+    assert "sharded_pytree" in sharded_storage.unsharded_buffers
+    
+    # Verify redistribute was called to replicate each tensor
+    mock_sharded1.redistribute.assert_called_with(
+        sharded_storage.mesh, placements=[Replicate()]
+    )
+    mock_sharded2.redistribute.assert_called_with(
+        sharded_storage.mesh, placements=[Replicate()]
+    )
+    mock_sharded3.redistribute.assert_called_with(
+        sharded_storage.mesh, placements=[Replicate()]
+    )
+
+    # 4. Delete sharded PyTree buffer
+    del sharded_storage["sharded_pytree"]
+    assert not sharded_storage.is_initialized("sharded_pytree")
+
+
 def test_materialize_all(sharded_storage):
     """Tests that materialize_all calls _materialize for each buffer."""
     sharded_storage.materialize_buffer = MagicMock()
@@ -165,4 +355,173 @@ def test_dematerialize_all(sharded_storage):
     sharded_storage.dematerialize_all()
     assert sharded_storage.dematerialize_buffer.call_count == 2
     sharded_storage.dematerialize_buffer.assert_any_call("buf1")
-    sharded_storage.dematerialize_buffer.assert_any_call("buf2") 
+    sharded_storage.dematerialize_buffer.assert_any_call("buf2")
+
+
+def test_accumulate_local_buffer(sharded_storage):
+    """Tests accumulation on a local buffer."""
+    config = BufferConfig(shard=False)
+    sharded_storage.register_buffer("local_acc", config)
+    
+    # Initial tensor
+    initial = torch.ones(5, 5)
+    sharded_storage["local_acc"] = initial
+    
+    # Accumulate
+    to_add = torch.ones(5, 5) * 2
+    sharded_storage.accumulate("local_acc", to_add)
+    
+    result = sharded_storage["local_acc"]
+    expected = torch.ones(5, 5) * 3
+    assert torch.allclose(result, expected)
+
+
+def test_accumulate_local_pytree(sharded_storage):
+    """Tests accumulation on a local PyTree buffer."""
+    config = BufferConfig(shard=False)
+    sharded_storage.register_buffer("local_pytree_acc", config)
+    
+    # Initial PyTree
+    initial = {
+        "tensor1": torch.ones(3, 3),
+        "tensor2": torch.ones(4, 4) * 2,
+        "nested": {
+            "tensor3": torch.ones(2, 2) * 3
+        }
+    }
+    sharded_storage["local_pytree_acc"] = initial
+    
+    # PyTree to accumulate
+    to_add = {
+        "tensor1": torch.ones(3, 3) * 0.5,
+        "tensor2": torch.ones(4, 4),
+        "nested": {
+            "tensor3": torch.ones(2, 2) * 2
+        }
+    }
+    sharded_storage.accumulate("local_pytree_acc", to_add)
+    
+    result = sharded_storage["local_pytree_acc"]
+    assert torch.allclose(result["tensor1"], torch.ones(3, 3) * 1.5)
+    assert torch.allclose(result["tensor2"], torch.ones(4, 4) * 3)
+    assert torch.allclose(result["nested"]["tensor3"], torch.ones(2, 2) * 5)
+
+
+@patch("torch.distributed.tensor.DTensor.from_local")
+def test_accumulate_sharded_buffer(mock_from_local, sharded_storage):
+    """Tests accumulation on a sharded buffer."""
+    config = BufferConfig(shard=True, shard_dim=0)
+    sharded_storage.register_buffer("sharded_acc", config)
+    
+    # Mock sharded tensor
+    mock_sharded = MagicMock()
+    mock_sharded.device_mesh = sharded_storage.mesh
+    sharded_storage.sharded_buffers["sharded_acc"] = mock_sharded
+    sharded_storage.buffer_states["sharded_acc"] = BufferState.SHARDED
+    
+    # Mock DTensor creation and redistribution
+    mock_partial_tensor = MagicMock()
+    mock_from_local.return_value = mock_partial_tensor
+    
+    mock_sharded_value = MagicMock()
+    mock_partial_tensor.redistribute.return_value = mock_sharded_value
+    
+    # Value to accumulate
+    to_add = torch.ones(10, 10)
+    sharded_storage.accumulate("sharded_acc", to_add)
+    
+    # Verify DTensor creation with Partial placement
+    mock_from_local.assert_called_once_with(
+        to_add,
+        device_mesh=sharded_storage.mesh,
+        placements=[Partial(reduce_op='sum')]
+    )
+    
+    # Verify redistribution to Shard placement
+    mock_partial_tensor.redistribute.assert_called_once_with(
+        sharded_storage.mesh,
+        placements=[Shard(config.shard_dim)]
+    )
+    
+    # Verify add_ was called on the sharded tensor
+    mock_sharded.add_.assert_called_once_with(mock_sharded_value)
+
+
+@patch("torch.distributed.tensor.DTensor.from_local")
+def test_accumulate_sharded_pytree(mock_from_local, sharded_storage):
+    """Tests accumulation on a sharded PyTree buffer."""
+    config = BufferConfig(shard=True, shard_dim=0)
+    sharded_storage.register_buffer("sharded_pytree_acc", config)
+    
+    # Mock sharded PyTree
+    mock_sharded_tensor1 = MagicMock()
+    mock_sharded_tensor2 = MagicMock()
+    mock_sharded_tensor3 = MagicMock()
+    
+    mock_sharded_pytree = {
+        "tensor1": mock_sharded_tensor1,
+        "tensor2": mock_sharded_tensor2,
+        "nested": {"tensor3": mock_sharded_tensor3}
+    }
+    sharded_storage.sharded_buffers["sharded_pytree_acc"] = mock_sharded_pytree
+    sharded_storage.buffer_states["sharded_pytree_acc"] = BufferState.SHARDED
+    
+    # Mock partial tensors that will be created
+    mock_partial1 = MagicMock()
+    mock_partial2 = MagicMock()
+    mock_partial3 = MagicMock()
+    
+    # Mock sharded values after redistribution
+    mock_sharded_value1 = MagicMock()
+    mock_sharded_value2 = MagicMock()
+    mock_sharded_value3 = MagicMock()
+    
+    # Setup redistribution
+    mock_partial1.redistribute.return_value = mock_sharded_value1
+    mock_partial2.redistribute.return_value = mock_sharded_value2
+    mock_partial3.redistribute.return_value = mock_sharded_value3
+    
+    # Counter to track which tensor we're processing
+    call_count = 0
+    tensor_to_partial = {}
+    
+    # PyTree to accumulate
+    to_add = {
+        "tensor1": torch.ones(10, 10),
+        "tensor2": torch.ones(20, 20),
+        "nested": {"tensor3": torch.ones(30, 30)}
+    }
+    
+    # Map tensors to their mocks before calling accumulate
+    tensor_to_partial[id(to_add["tensor1"])] = mock_partial1
+    tensor_to_partial[id(to_add["tensor2"])] = mock_partial2
+    tensor_to_partial[id(to_add["nested"]["tensor3"])] = mock_partial3
+    
+    def from_local_side_effect(tensor, **kwargs):
+        return tensor_to_partial.get(id(tensor), MagicMock())
+    
+    mock_from_local.side_effect = from_local_side_effect
+    
+    sharded_storage.accumulate("sharded_pytree_acc", to_add)
+    
+    # Verify DTensor.from_local was called for each tensor
+    assert mock_from_local.call_count == 3
+    
+    # Verify redistribution was called on each partial tensor
+    mock_partial1.redistribute.assert_called_once_with(
+        sharded_storage.mesh,
+        placements=[Shard(config.shard_dim)]
+    )
+    mock_partial2.redistribute.assert_called_once_with(
+        sharded_storage.mesh,
+        placements=[Shard(config.shard_dim)]
+    )
+    mock_partial3.redistribute.assert_called_once_with(
+        sharded_storage.mesh,
+        placements=[Shard(config.shard_dim)]
+    )
+    
+    # Verify add_ was called on each tensor in the sharded PyTree
+    mock_sharded_tensor1.add_.assert_called_once_with(mock_sharded_value1)
+    mock_sharded_tensor2.add_.assert_called_once_with(mock_sharded_value2)
+    mock_sharded_tensor3.add_.assert_called_once_with(mock_sharded_value3) 

--- a/tests/utils/test_sharded_storage.py
+++ b/tests/utils/test_sharded_storage.py
@@ -160,9 +160,8 @@ def test_delete_buffer_pytree(sharded_storage):
     assert sharded_storage.buffer_states["pytree_to_delete"] == BufferState.UNINITIALIZED
 
 
-@patch("kronfluence.utils.sharded_storage.release_memory")
 @patch("torch.distributed.tensor.DTensor.from_local")
-def test_sharded_buffer_lifecycle(mock_from_local, mock_release_memory, sharded_storage, mock_state):
+def test_sharded_buffer_lifecycle(mock_from_local, sharded_storage, mock_state):
     """Tests the full state transition lifecycle of a sharded buffer."""
     mock_replicated_tensor = MagicMock()
     mock_from_local.return_value = mock_replicated_tensor
@@ -197,7 +196,6 @@ def test_sharded_buffer_lifecycle(mock_from_local, mock_release_memory, sharded_
     )
     assert sharded_storage.sharded_buffers["sharded_buffer"] is mock_sharded_tensor
     mock_state.wait_for_everyone.assert_called_once()
-    mock_release_memory.assert_called_once()
     with pytest.raises(ValueError):
         _ = sharded_storage["sharded_buffer"]
 
@@ -211,21 +209,18 @@ def test_sharded_buffer_lifecycle(mock_from_local, mock_release_memory, sharded_
 
     # 4. Dematerialize again -> SHARDED
     mock_state.wait_for_everyone.reset_mock()
-    mock_release_memory.reset_mock()
     sharded_storage.dematerialize_buffer("sharded_buffer")
     assert sharded_storage.buffer_states["sharded_buffer"] == BufferState.SHARDED
     assert "sharded_buffer" not in sharded_storage.unsharded_buffers
     mock_state.wait_for_everyone.assert_called_once()
-    mock_release_memory.assert_called_once()
 
     # 5. Delete sharded buffer
     del sharded_storage["sharded_buffer"]
     assert not sharded_storage.is_initialized("sharded_buffer")
 
 
-@patch("kronfluence.utils.sharded_storage.release_memory")
 @patch("torch.distributed.tensor.DTensor.from_local")
-def test_sharded_pytree_lifecycle(mock_from_local, mock_release_memory, sharded_storage, mock_state):
+def test_sharded_pytree_lifecycle(mock_from_local, sharded_storage, mock_state):
     """Tests the full state transition lifecycle of a sharded PyTree buffer."""
     config = BufferConfig(shard=True, shard_dim=0)
     sharded_storage.register_buffer("sharded_pytree", config)

--- a/tests/utils/test_sharded_storage.py
+++ b/tests/utils/test_sharded_storage.py
@@ -1,0 +1,163 @@
+import pytest
+import torch
+from unittest.mock import MagicMock, patch
+
+from kronfluence.utils.sharded_storage import (
+    ShardedStorage,
+    BufferConfig,
+    BufferState,
+)
+from kronfluence.utils.state import State
+from torch.distributed.tensor.placement_types import Replicate, Shard
+
+
+@pytest.fixture
+def mock_state():
+    """Mocks the State object."""
+    state = MagicMock(spec=State)
+    state.device = torch.device("cpu")
+    state.num_processes = 1
+    state.wait_for_everyone = MagicMock()
+    return state
+
+
+@pytest.fixture
+def sharded_storage(mock_state):
+    """Provides a ShardedStorage instance with a mocked DeviceMesh."""
+    with patch("kronfluence.utils.sharded_storage.DeviceMesh") as mock_device_mesh:
+        mesh_instance = MagicMock()
+        mock_device_mesh.return_value = mesh_instance
+        storage = ShardedStorage(state=mock_state, mesh=mesh_instance)
+        return storage
+
+
+def test_register_buffer(sharded_storage):
+    """Tests the registration of a buffer."""
+    config = BufferConfig(shard=False)
+    sharded_storage.register_buffer("test_buffer", config)
+    assert "test_buffer" in sharded_storage
+    assert sharded_storage.buffer_states["test_buffer"] == BufferState.UNINITIALIZED
+    assert not sharded_storage.is_initialized("test_buffer")
+    assert sharded_storage["test_buffer"] is None
+
+
+def test_set_and_get_local_buffer(sharded_storage):
+    """Tests setting, getting, and deleting a non-sharded buffer."""
+    config = BufferConfig(shard=False)
+    sharded_storage.register_buffer("local_buffer", config)
+    tensor = torch.randn(10)
+    sharded_storage["local_buffer"] = tensor
+
+    assert sharded_storage.buffer_states["local_buffer"] == BufferState.LOCAL
+    assert sharded_storage.is_initialized("local_buffer")
+    assert torch.equal(sharded_storage["local_buffer"], tensor)
+
+    # Test deletion by setting to None.
+    sharded_storage["local_buffer"] = None
+    assert sharded_storage.buffer_states["local_buffer"] == BufferState.UNINITIALIZED
+    assert not sharded_storage.is_initialized("local_buffer")
+    assert sharded_storage["local_buffer"] is None
+
+
+def test_set_sharded_buffer(sharded_storage):
+    """Tests setting a sharded buffer, which should put it in the NEEDS_SHARDING state."""
+    config = BufferConfig(shard=True)
+    sharded_storage.register_buffer("sharded_buffer", config)
+    tensor = torch.randn(10)
+    sharded_storage["sharded_buffer"] = tensor
+
+    assert sharded_storage.buffer_states["sharded_buffer"] == BufferState.NEEDS_SHARDING
+    assert torch.equal(sharded_storage["sharded_buffer"], tensor)
+
+
+def test_delete_buffer(sharded_storage):
+    """Tests the deletion of a buffer."""
+    config = BufferConfig(shard=False)
+    sharded_storage.register_buffer("buffer_to_delete", config)
+    tensor = torch.randn(10)
+    sharded_storage["buffer_to_delete"] = tensor
+
+    assert sharded_storage.is_initialized("buffer_to_delete")
+    del sharded_storage["buffer_to_delete"]
+    assert not sharded_storage.is_initialized("buffer_to_delete")
+    assert sharded_storage.buffer_states["buffer_to_delete"] == BufferState.UNINITIALIZED
+
+
+@patch("kronfluence.utils.sharded_storage.release_memory")
+@patch("torch.distributed.tensor.DTensor.from_local")
+def test_sharded_buffer_lifecycle(mock_from_local, mock_release_memory, sharded_storage, mock_state):
+    """Tests the full state transition lifecycle of a sharded buffer."""
+    mock_dtensor_instance = MagicMock()
+    mock_from_local.return_value = mock_dtensor_instance
+
+    mock_replicated_tensor = torch.randn(20)
+
+    def redistribute_effect(mesh, placements):
+        return mock_replicated_tensor
+
+    mock_dtensor_instance.redistribute.side_effect = redistribute_effect
+
+    config = BufferConfig(shard=True, shard_dim=0)
+    sharded_storage.register_buffer("sharded_buffer", config)
+    tensor = torch.randn(20)
+
+    # 1. Set tensor -> NEEDS_SHARDING
+    sharded_storage["sharded_buffer"] = tensor
+    assert sharded_storage.buffer_states["sharded_buffer"] == BufferState.NEEDS_SHARDING
+    assert torch.equal(sharded_storage["sharded_buffer"], tensor)
+
+    # 2. Dematerialize -> SHARDED
+    sharded_storage._dematerialize("sharded_buffer")
+    assert sharded_storage.buffer_states["sharded_buffer"] == BufferState.SHARDED
+    mock_from_local.assert_called_once_with(
+        tensor, device_mesh=sharded_storage.mesh, placements=[Shard(config.shard_dim)]
+    )
+    assert sharded_storage.sharded_buffers["sharded_buffer"] is mock_dtensor_instance
+    mock_state.wait_for_everyone.assert_called_once()
+    mock_release_memory.assert_called_once()
+    with pytest.raises(ValueError):
+        _ = sharded_storage["sharded_buffer"]
+
+    # 3. Materialize -> REPLICATED
+    sharded_storage._materialize("sharded_buffer")
+    assert sharded_storage.buffer_states["sharded_buffer"] == BufferState.REPLICATED
+    mock_dtensor_instance.redistribute.assert_called_once_with(
+        sharded_storage.mesh, placements=[Replicate()]
+    )
+    assert torch.equal(sharded_storage["sharded_buffer"], mock_replicated_tensor)
+    assert "sharded_buffer" in sharded_storage.unsharded_buffers
+
+    # 4. Dematerialize again -> SHARDED
+    mock_state.wait_for_everyone.reset_mock()
+    mock_release_memory.reset_mock()
+    sharded_storage._dematerialize("sharded_buffer")
+    assert sharded_storage.buffer_states["sharded_buffer"] == BufferState.SHARDED
+    assert "sharded_buffer" not in sharded_storage.unsharded_buffers
+    mock_state.wait_for_everyone.assert_called_once()
+    mock_release_memory.assert_called_once()
+
+    # 5. Delete sharded buffer
+    del sharded_storage["sharded_buffer"]
+    assert not sharded_storage.is_initialized("sharded_buffer")
+
+
+def test_materialize_all(sharded_storage):
+    """Tests that materialize_all calls _materialize for each buffer."""
+    sharded_storage._materialize = MagicMock()
+    sharded_storage.register_buffer("buf1", BufferConfig())
+    sharded_storage.register_buffer("buf2", BufferConfig())
+    sharded_storage.materialize_all()
+    assert sharded_storage._materialize.call_count == 2
+    sharded_storage._materialize.assert_any_call("buf1")
+    sharded_storage._materialize.assert_any_call("buf2")
+
+
+def test_dematerialize_all(sharded_storage):
+    """Tests that dematerialize_all calls _dematerialize for each buffer."""
+    sharded_storage._dematerialize = MagicMock()
+    sharded_storage.register_buffer("buf1", BufferConfig())
+    sharded_storage.register_buffer("buf2", BufferConfig())
+    sharded_storage.dematerialize_all()
+    assert sharded_storage._dematerialize.call_count == 2
+    sharded_storage._dematerialize.assert_any_call("buf1")
+    sharded_storage._dematerialize.assert_any_call("buf2") 


### PR DESCRIPTION
This PR implements a basic approach to sharding the model Hessian across devices using a process similar to FSDP.

### Description of Changes
Most of the functionality for this is implemented in kronfluence/utils/sharded_storage.py. An instance of this class then replaces the storage dictionary used by kronfluence tracked modules. This allows each Tracked Module to configure how the tensors stores should be shared across a device mesh and when they should be gathered.

We also update the wikitext and openwebtext examples to support hessian sharding as an option and FSDP2.